### PR TITLE
fix-broken-timezone conversion

### DIFF
--- a/scripts/evcc-influx-aggregate.sh
+++ b/scripts/evcc-influx-aggregate.sh
@@ -150,8 +150,8 @@ writeDailyEnergies() {
     printf -v fDay "%02d" $day
 
     # Convert time to UTC for local timezone
-    fromTime=$(date -d "`date -d ${fYear}-${fMonth}-${fDay}T00:00:00`" -u +%FT%R:00Z)
-    toTime=$(date -d "`date -d ${fYear}-${fMonth}-${fDay}T23:59:59`" -u +%FT%R:00Z)
+    fromTime=$(date -d "`date -d ${fYear}-${fMonth}-${fDay}T00:00:00 +%FT%R%Z`" -u +%FT%R:00Z)
+    toTime=$(date -d "`date -d ${fYear}-${fMonth}-${fDay}T23:59:59 +%FT%R%Z`" -u +%FT%R:00Z)
     timeCondition="time >= '${fromTime}' AND time <= '${toTime}'"
 
     query=""
@@ -235,8 +235,8 @@ writeMonthlyEnergies () {
     printf -v fDays "%02d" $numDays
 
     # Convert time to UTC for local timezone
-    fromTime=$(date -d "`date -d ${fYear}-${fMonth}-01T00:00:00`" -u +%FT%R:00Z)
-    toTime=$(date -d "`date -d ${fYear}-${fMonth}-${fDays}T23:59:59`" -u +%FT%R:00Z)
+    fromTime=$(date -d "`date -d ${fYear}-${fMonth}-01T00:00:00 +%FT%R%Z`" -u +%FT%R:00Z)
+    toTime=$(date -d "`date -d ${fYear}-${fMonth}-${fDays}T23:59:59 +%FT%R%Z`" -u +%FT%R:00Z)
     timeCondition="time >= '${fromTime}' AND time <= '${toTime}'"
 
     logDebug "${fYear}-${fMonth}: Creating monthly aggregation from $dailyEnergyMeasurement into ${monthlyEnergyMeasurement}"


### PR DESCRIPTION
When running the aggregations script you might get these errors:

```
date: invalid date ‘Tue  1 Oct 00:00:00 CEST 2024’
date: invalid date ‘Thu 31 Oct 23:59:59 CET 2024’
invalid operation: time and *influxql.StringLiteral are not compatible
```

This should fix this problem. No idea why it worked yesterday and today it doesn't anymore.