### PR TITLE
Aggregations can be stored in a separate DB now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Dieser Thread ["InfluxDB und Grafana"](https://github.com/evcc-io/evcc/discussio
    6. Wieder Influx auswählen.
    7. Dieselben Daten, wie oben eintragen, aber
       - Name: 'EVCC Aggregations'
-      - Database: 'evcc_aggr'
+      - Database: 'evcc_aggr' (oder dieselbe DB wie oben, wenn keine getrennte DB gewünscht ist)
 
 3. Dashboards über den Grafana.com Community Store installieren:
    1. In Grafana unter 'Dashboards' auf 'New/Import' clicken:

--- a/README.md
+++ b/README.md
@@ -52,14 +52,22 @@ Dieser Thread ["InfluxDB und Grafana"](https://github.com/evcc-io/evcc/discussio
 
 ### Installation der Dashboards in Grafana
 
-1. Data Source unter 'Connections /  Data Sources' anlegen. 
+
+1. Daten Aggregations Script wie [unter 'scripts beschrieben](./scripts/README.md) anpassen und installieren (ohne dieses werden die Dashboards für Monat, Jahr und Finanz nicht laufen).
+
+2. Data Sources unter 'Connections /  Data Sources' anlegen. 
    1. Oben rechts auf '+ Add new data source' clicken.
    2. 'InfluxDB' auswählen.
    3. Daten wie im Bild unten eintragen. 'URL', 'Database', 'User' und 'Passwort' müssen natürlich passend auf die eigene DB angepasst werden.
       ![Data Source anlegen](./img/create-datasource.png)
    4. Auf 'Save & test' clicken.
+   5. Eine weitere Data Source für die Aggregations DB hinzufügen.
+   6. Wieder Influx auswählen.
+   7. Dieselben Daten, wie oben eintragen, aber
+      - Name: 'EVCC Aggregations'
+      - Database: 'evcc_aggr'
 
-2. Dashboards über den Grafana.com Community Store installieren:
+3. Dashboards über den Grafana.com Community Store installieren:
    1. In Grafana unter 'Dashboards' auf 'New/Import' clicken:
       ![Import dashboard](./img/import.png)
    2. Unter "Find and import dashboards..." folgende Dashboards mit folgenden IDs importieren:
@@ -73,9 +81,7 @@ Dieser Thread ["InfluxDB und Grafana"](https://github.com/evcc-io/evcc/discussio
 
       Bei jedem Import jeweils die oben angelegte InfluxDB Data Source auswählen.
 
-3. Dashboards wie [unter 'dashboards' beschrieben](./dashboards/README.md) anpassen.
-
-4. Daten Aggregation Script wie [unter 'scripts beschrieben](./scripts/README.md) anpassen und installieren (ohne dieses werden die Dashboards für Monat, Jahr und Finanz nicht laufen).
+4. Dashboards wie [unter 'dashboards' beschrieben](./dashboards/README.md) anpassen.
 
 
 ## Upgrade

--- a/dashboards/dashboards/EVCC_ All-time.json
+++ b/dashboards/dashboards/EVCC_ All-time.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_EVCC_INFLUXDB",
-      "label": "EVCC InfluxDB",
+      "name": "DS_EVCC_AGGREGRATIONS",
+      "label": "EVCC Aggregrations",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -24,7 +24,7 @@
       "model": {
         "datasource": {
           "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "uid": "${DS_EVCC_AGGREGRATIONS}"
         },
         "description": "",
         "fieldConfig": {
@@ -164,7 +164,7 @@
             "alias": "Netzbezug",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") /1000 from gridDailyEnergy WHERE $timeFilter  tz('$timezone')",
@@ -176,7 +176,7 @@
             "alias": "PV",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -219,7 +219,7 @@
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -262,7 +262,7 @@
             "alias": "loadpoint1",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -305,7 +305,7 @@
             "alias": "loadpoint2",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -348,7 +348,7 @@
             "alias": "Eingespeist",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") /1000 from feedInDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -369,7 +369,7 @@
       "model": {
         "datasource": {
           "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "uid": "${DS_EVCC_AGGREGRATIONS}"
         },
         "description": "",
         "fieldConfig": {
@@ -476,7 +476,7 @@
             "alias": "PV",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -519,7 +519,7 @@
           {
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": true,
             "query": "SELECT sum(\"value\") from gridDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -530,7 +530,7 @@
           {
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": true,
             "query": "SELECT sum(\"value\") from feedInDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -542,7 +542,7 @@
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -585,7 +585,7 @@
             "alias": "Loadpoint1",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -628,7 +628,7 @@
             "alias": "Loadpoint2",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -805,7 +805,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "Die Legende sollte das Jahr anzeigen, aber ein Bug in Grafana verhindert das: https://github.com/grafana/grafana/issues/87332",
       "fieldConfig": {
@@ -943,7 +943,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1047,7 +1047,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1186,7 +1186,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1277,7 +1277,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1416,7 +1416,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1507,7 +1507,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1646,7 +1646,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1750,7 +1750,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1921,7 +1921,7 @@
           "alias": "30 Tage Hausverbrauch",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1964,7 +1964,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2007,7 +2007,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2070,7 +2070,7 @@
           "alias": "zugekauftTaeglich",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2123,7 +2123,7 @@
           "alias": "Einspeisung",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2189,7 +2189,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "Bei weniger als 365 Tagen wird anhand der bisherigen Daten auf das Jahr hochgerechnet mit entsprechender Ungenauigkeit je nach erfasstem Zeitraum.",
       "fieldConfig": {
@@ -2267,7 +2267,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Prognose basierend auf"
+                "value": "Prognose basiert auf"
               },
               {
                 "id": "unit",
@@ -2450,7 +2450,7 @@
           "alias": "Hausverbrauch",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2493,7 +2493,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2536,7 +2536,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2598,7 +2598,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT sum(\"value\") from gridMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -2619,7 +2619,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT sum(\"value\") from feedInMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -2661,7 +2661,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2748,7 +2748,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "Bei weniger als 365 Tagen wird anhand der bisherigen Daten auf das Jahr hochgerechnet mit entsprechender Ungenauigkeit je nach erfasstem Zeitraum.",
       "fieldConfig": {
@@ -2778,7 +2778,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Prognose basierend auf"
+                "value": "Prognose basiert auf"
               },
               {
                 "id": "unit",
@@ -2971,7 +2971,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -3024,7 +3024,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT sum(\"value\") from chargeMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -3035,7 +3035,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT sum(\"value\") from dischargeMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -3360,6 +3360,6 @@
   "timezone": "",
   "title": "EVCC: All-time",
   "uid": "LY-opIigz",
-  "version": 167,
+  "version": 169,
   "weekStart": ""
 }

--- a/dashboards/dashboards/EVCC_ Jahr.json
+++ b/dashboards/dashboards/EVCC_ Jahr.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_EVCC_INFLUXDB",
-      "label": "EVCC InfluxDB",
+      "name": "DS_EVCC_AGGREGRATIONS",
+      "label": "EVCC Aggregrations",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -14,6 +14,14 @@
       "description": "",
       "type": "datasource",
       "pluginId": "__expr__"
+    },
+    {
+      "name": "DS_EVCC_INFLUXDB",
+      "label": "EVCC InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
     }
   ],
   "__elements": {
@@ -24,7 +32,7 @@
       "model": {
         "datasource": {
           "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "uid": "${DS_EVCC_AGGREGRATIONS}"
         },
         "description": "",
         "fieldConfig": {
@@ -164,7 +172,7 @@
             "alias": "Netzbezug",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") /1000 from gridDailyEnergy WHERE $timeFilter  tz('$timezone')",
@@ -176,7 +184,7 @@
             "alias": "PV",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -219,7 +227,7 @@
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -262,7 +270,7 @@
             "alias": "loadpoint1",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -305,7 +313,7 @@
             "alias": "loadpoint2",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -348,7 +356,7 @@
             "alias": "Eingespeist",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") /1000 from feedInDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -369,7 +377,7 @@
       "model": {
         "datasource": {
           "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "uid": "${DS_EVCC_AGGREGRATIONS}"
         },
         "description": "",
         "fieldConfig": {
@@ -476,7 +484,7 @@
             "alias": "PV",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -519,7 +527,7 @@
           {
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": true,
             "query": "SELECT sum(\"value\") from gridDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -530,7 +538,7 @@
           {
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": true,
             "query": "SELECT sum(\"value\") from feedInDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -542,7 +550,7 @@
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -585,7 +593,7 @@
             "alias": "Loadpoint1",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -628,7 +636,7 @@
             "alias": "Loadpoint2",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -701,8 +709,8 @@
       "kind": 1,
       "model": {
         "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "type": "datasource",
+          "uid": "-- Mixed --"
         },
         "description": "",
         "fieldConfig": {
@@ -852,7 +860,7 @@
             "alias": "Speicher laden",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") from chargeDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -864,7 +872,7 @@
             "alias": "Speicher entladen",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") from dischargeDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -1128,7 +1136,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1303,7 +1311,7 @@
           "alias": "Erzeugt von PV",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1346,7 +1354,7 @@
           "alias": "Zugekauft",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1389,7 +1397,7 @@
           "alias": "Haus",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1432,7 +1440,7 @@
           "alias": "Garage",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1475,7 +1483,7 @@
           "alias": "Stellplatz",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1518,7 +1526,7 @@
           "alias": "Eingespeist",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1577,7 +1585,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1681,7 +1689,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1723,7 +1731,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1765,7 +1773,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1807,7 +1815,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1859,7 +1867,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1901,7 +1909,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT value FROM \"feedInMonthlyEnergy\" WHERE $timeFilter tz('$timezone')",
@@ -1926,7 +1934,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2043,7 +2051,7 @@
           "alias": "PV Energie",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2102,7 +2110,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -2219,7 +2227,7 @@
           "alias": "Einspeisung",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2278,7 +2286,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2393,7 +2401,7 @@
           "alias": "Hausverbrauch",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2452,7 +2460,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -2552,7 +2560,7 @@
           "alias": "Erzeugt/Tag",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2595,7 +2603,7 @@
           "alias": "Verbraucht/Tag",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2638,7 +2646,7 @@
           "alias": "Verbraucht/Tag",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2681,7 +2689,7 @@
           "alias": "Verbraucht/Tag",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2734,7 +2742,7 @@
           "alias": "Zugekauft/Tag",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2781,7 +2789,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -2907,7 +2915,7 @@
           "alias": "Erzeugt",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2950,7 +2958,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2993,7 +3001,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -3036,7 +3044,7 @@
           "alias": "",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -3089,7 +3097,7 @@
           "alias": "Zugekauft",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -3404,7 +3412,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -3525,7 +3533,7 @@
           "alias": "Speicher laden",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": false,
           "query": "SELECT \"value\" from chargeMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -3537,7 +3545,7 @@
           "alias": "Speicher entladen",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": false,
           "query": "SELECT \"value\" from dischargeMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -3552,7 +3560,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -3659,7 +3667,7 @@
           "alias": "Speicher laden",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT \"value\" from chargeMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -3671,7 +3679,7 @@
           "alias": "Speicher entladen",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT \"value\" from dischargeMonthlyEnergy WHERE $timeFilter tz('$timezone')",
@@ -3765,6 +3773,6 @@
   "timezone": "",
   "title": "EVCC: Jahr",
   "uid": "Bdgi-xggk",
-  "version": 153,
+  "version": 157,
   "weekStart": ""
 }

--- a/dashboards/dashboards/EVCC_ Monat.json
+++ b/dashboards/dashboards/EVCC_ Monat.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_EVCC_INFLUXDB",
-      "label": "EVCC InfluxDB",
+      "name": "DS_EVCC_AGGREGRATIONS",
+      "label": "EVCC Aggregrations",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
@@ -14,6 +14,14 @@
       "description": "",
       "type": "datasource",
       "pluginId": "__expr__"
+    },
+    {
+      "name": "DS_EVCC_INFLUXDB",
+      "label": "EVCC InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
     }
   ],
   "__elements": {
@@ -24,7 +32,7 @@
       "model": {
         "datasource": {
           "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "uid": "${DS_EVCC_AGGREGRATIONS}"
         },
         "description": "",
         "fieldConfig": {
@@ -164,7 +172,7 @@
             "alias": "Netzbezug",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") /1000 from gridDailyEnergy WHERE $timeFilter  tz('$timezone')",
@@ -176,7 +184,7 @@
             "alias": "PV",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -219,7 +227,7 @@
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -262,7 +270,7 @@
             "alias": "loadpoint1",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -305,7 +313,7 @@
             "alias": "loadpoint2",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -348,7 +356,7 @@
             "alias": "Eingespeist",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") /1000 from feedInDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -369,7 +377,7 @@
       "model": {
         "datasource": {
           "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "uid": "${DS_EVCC_AGGREGRATIONS}"
         },
         "description": "",
         "fieldConfig": {
@@ -476,7 +484,7 @@
             "alias": "PV",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -519,7 +527,7 @@
           {
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": true,
             "query": "SELECT sum(\"value\") from gridDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -530,7 +538,7 @@
           {
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": true,
             "query": "SELECT sum(\"value\") from feedInDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -542,7 +550,7 @@
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -585,7 +593,7 @@
             "alias": "Loadpoint1",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -628,7 +636,7 @@
             "alias": "Loadpoint2",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "groupBy": [
               {
@@ -701,8 +709,8 @@
       "kind": 1,
       "model": {
         "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
+          "type": "datasource",
+          "uid": "-- Mixed --"
         },
         "description": "",
         "fieldConfig": {
@@ -852,7 +860,7 @@
             "alias": "Speicher laden",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") from chargeDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -864,7 +872,7 @@
             "alias": "Speicher entladen",
             "datasource": {
               "type": "influxdb",
-              "uid": "L-nZgczgk"
+              "uid": "fe8sr664fohz4a"
             },
             "hide": false,
             "query": "SELECT sum(\"value\") from dischargeDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -1116,7 +1124,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1306,7 +1314,7 @@
           "alias": "PV",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1349,7 +1357,7 @@
           "alias": "Zugekauft",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1392,7 +1400,7 @@
           "alias": "Haus",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": false,
           "query": "SELECT value * (-1) FROM homeDailyEnergy WHERE $timeFilter  tz('$timezone')",
@@ -1404,7 +1412,7 @@
           "alias": "loadpoint1",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": false,
           "query": "SELECT value * (-1) FROM loadpoint1DailyEnergy WHERE $timeFilter  tz('$timezone')",
@@ -1416,7 +1424,7 @@
           "alias": "loadpoint2",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": false,
           "query": "SELECT value * (-1) FROM loadpoint2DailyEnergy WHERE $timeFilter  tz('$timezone')",
@@ -1428,7 +1436,7 @@
           "alias": "Eingespeist",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1474,7 +1482,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1527,7 +1535,7 @@
           "alias": "PV",
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1735,7 +1743,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "${DS_EVCC_INFLUXDB}"
+        "uid": "${DS_EVCC_AGGREGRATIONS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1865,7 +1873,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT value FROM gridDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -1876,7 +1884,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1918,7 +1926,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -1960,7 +1968,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2012,7 +2020,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "groupBy": [
             {
@@ -2054,7 +2062,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": true,
           "query": "SELECT value FROM feedInDailyEnergy WHERE $timeFilter tz('$timezone')",
@@ -2393,6 +2401,6 @@
   "timezone": "",
   "title": "EVCC: Monat",
   "uid": "4iQda7igz",
-  "version": 159,
+  "version": 160,
   "weekStart": ""
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,14 +5,34 @@ Irgendwann war der Raspberry PI heillos damit überfordert alle Daten live zusam
 # Installation
 
 1. Script [`evcc-influx-aggregate.sh`](./evcc-influx-aggregate.sh) herunterladen und auf ein Linux System kopieren. Idealerweise ist dies das system (oder die VM) auf der die InfluxDB läuft. Falls dies nicht möglicht ist (z.B. HAOS), kann das script auch remote von einem anderen Linux System ausgeführt werden.
+
 2. Script mit Zugangsdaten für Influx oben anpassen:
    ```bash
    #consts
-   INFLUXDB="evcc" # Name of the Influx DB, where you write the EVCC data into
-   INFLUX_USER="" # Your user name. Empty, if no user is required.
-   INFLUX_PASSWORD="none" # can be anything except an empty string in case no password is set
+   INFLUX_EVCC_DB="evcc" # Name of the Influx DB, where you write the EVCC data into.
+   INFLUX_EVCC_USER="" # User name of the EVCC DB. Empty, if no user is required. Default: ""
+   INFLUX_EVCC_PASSWORD="none" # Password of the EVCC DB user. Can be anything except an empty string in case no password is set.  Default: "none"
     ```
-3. Wird das Script auf demselben System installiert auf dem auch die Influx DB läuft, kann dieser Schritt übersprungen werden. Falls das Script nicht lokal auf dem System läuft, wo die InfluxDB läuft:
+3. Getrennte Datenbank für Aggregation anlegen. Falls keine getrennte Datenbank gewünscht wird können auch die Zugangsdaten aus dem vorherigen Schritt wiederholt werden.
+   1. Auf dem Influx server das `influx` CLI starten
+   2. Datenbank anlegen (hier nennen wir die DB 'evcc_aggr'): 
+      
+      `create database evcc_aggr`
+   3. Datenbank benutzen: 
+      
+      `use evcc_aggr`
+   4. Einen User 'grafana' anlegen. Falls gewünscht mit Password: 
+      
+      `create user grafana with password '' with all privileges`
+
+   5. Zugangsdaten für Aggregations DB im Script anpassen:
+      ```bash
+      INFLUX_AGGR_DB="evcc_aggr" # Name of the Influx DB, where you write the aggregations into.
+      INFLUX_AGGR_USER="" # User name of the aggregation DB. Empty, if no user is required. Default: ""
+      INFLUX_AGGR_PASSWORD="none" # Password of the aggreation DB user. Can be anything except an empty string in case no password is set.  Default: "none"
+      ````
+
+3. Wird das Script auf demselben System installiert auf dem auch die Influx DB läuft, kann dieser Schritt übersprungen werden. Falls das Script nicht lokal auf dem System läuft, auf dem die InfluxDB läuft:
    1. Influx Client installieren. Je nach Linuxderivat z.B. `apt-get install influxdb-client`
    2. Mit `influx -version` überprüfen, dass es der Client mit der richtigen Version ist (muss 1.8.x sein)
      ```
@@ -25,16 +45,19 @@ Irgendwann war der Raspberry PI heillos damit überfordert alle Daten live zusam
      INFLUX_HOST="localhost" # If the script is run remotely, enter the host name of the remote host. Default: "localhost"
      INFLUX_PORT=8086 # The port to connect to influx. Default: 8086
      ```
+
 4. Falls kein Heimspeicher vorhanden ist, kann dessen Aggregation deaktiviert werden:
    ```bash
    HOME_BATTERY="true" # set to false in case your home does not use a battery
    ```
+
 5. Loadpoints müssen mit den Titeln, wie sie in der evcc.yaml definiert worden sind angegeben werden. Ein zweiter Loadpoint kann ggf. deaktiviert werden.
    ```bash
    LOADPOINT_1_TITLE="Garage" # title of loadpoint 1 as defined in evcc.yaml
    LOADPOINT_2_ENABLED=true # set to false in case you have just one loadpoint
    LOADPOINT_2_TITLE="Stellplatz" # title of loadpoint 2 as defined in evcc.yaml
    ```
+
 6. Gegebenfalls muss die Zeitzone angepasst werden.
    ```bash
    TIMEZONE="Europe/Berlin" #Time zone as in TZ identifier column here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
@@ -42,12 +65,15 @@ Irgendwann war der Raspberry PI heillos damit überfordert alle Daten live zusam
    Gültige Werte für die Zeitzone finden man in [dieser Liste auf Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) in the Spalte 'TZ Identifier'.
 
    Bitte beachten, dass die System-Zeitzone des Systems, auf dem dieses Script ausgeführt wird, auf dieselbe Zeitzone konfiguriert sein muss.
+
 6. `chmod +x evcc-influx-aggregate.sh`
+
 7. Für jedes Jahr, für das die Influx DB bereits mit EVCC Daten gefüllt ist, eine Aggregierung des gesamten Jahres starten:
    ```bash
    ./evcc-influx-aggregate.sh --year 2024
    ```
    Das wird nun etwas dauern.
+
 8. Mit Hilfe von `crontab -e` folgende regelmäßige Aufrufe konfigurieren:
    ```
    5 0 * * * <PATH_TO_SCRIPT>/evcc-influx-aggregate.sh --yesterday >> /var/log/evcc-grafana-dashboards.log 2>&1

--- a/scripts/evcc-influx-aggregate.sh
+++ b/scripts/evcc-influx-aggregate.sh
@@ -247,7 +247,7 @@ writeMonthlyEnergies () {
     query="SELECT sum(\"$field\") FROM $dailyEnergyMeasurement WHERE ${timeCondition} tz('$TIMEZONE')"
     logDebug "Query: $query"
 
-    queryResult=`influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_EVCC_DB -username "$INFLUX_EVCC_USER" -password "$INFLUX_EVCC_PASSWORD" -precision rfc3339 -execute "$query" | tail -n 1`
+    queryResult=`influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_AGGR_DB -username "$INFLUX_AGGR_USER" -password "$INFLUX_AGGR_PASSWORD" -precision rfc3339 -execute "$query" | tail -n 1`
     logDebug "Query result (last row): $queryResult"
     if [ `echo $queryResult | wc -w ` -eq 2 ]; then
         timestamp=`echo "$queryResult" | cut -d " " -f 1`

--- a/scripts/evcc-influx-aggregate.sh
+++ b/scripts/evcc-influx-aggregate.sh
@@ -3,9 +3,12 @@
 # Aggregate date into daily chunks
 
 #consts
-INFLUXDB="evcc" # Name of the Influx DB, where you write the EVCC data into.
-INFLUX_USER="" # Your user name. Empty, if no user is required. Default: ""
-INFLUX_PASSWORD="none" # can be anything except an empty string in case no password is set.  Default: "none"
+INFLUX_EVCC_DB="evcc" # Name of the Influx DB, where you write the EVCC data into.
+INFLUX_EVCC_USER="" # User name of the EVCC DB. Empty, if no user is required. Default: ""
+INFLUX_EVCC_PASSWORD="none" # Password of the EVCC DB user. Can be anything except an empty string in case no password is set.  Default: "none"
+INFLUX_AGGR_DB="evcc_aggr" # Name of the Influx DB, where you write the aggregations into.
+INFLUX_AGGR_USER="" # User name of the aggregation DB. Empty, if no user is required. Default: ""
+INFLUX_AGGR_PASSWORD="none" # Password of the aggreation DB user. Can be anything except an empty string in case no password is set.  Default: "none"
 INFLUX_HOST="localhost" # If the script is run remotely, enter the host name of the remote host. Default: "localhost"
 INFLUX_PORT=8086 # The port to connect to influx. Default: 8086
 HOME_BATTERY="true" # Set to false in case your home does not use a battery.
@@ -14,7 +17,7 @@ LOADPOINT_1_TITLE="Garage" # Title of loadpoint 1 as defined in evcc.yaml
 LOADPOINT_2_ENABLED=true # Set to false in case you have just one loadpoint
 LOADPOINT_2_TITLE="Stellplatz" # Title of loadpoint 2 as defined in evcc.yaml
 TIMEZONE="Europe/Berlin" # Time zone as in TZ identifier column here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
-PEAK_POWER_LIMIT=25000 # Limit in W to sanitize unrealistic peaks
+PEAK_POWER_LIMIT=25000 # Limit in W to filter out unrealistic peaks
 
 #arguments
 AGGREGATE_YEAR=0
@@ -180,7 +183,7 @@ writeDailyEnergies() {
     esac
     logDebug "Query: $query"
 
-    queryResult=`influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUXDB -username "$INFLUX_USER" -password "$INFLUX_PASSWORD" -precision rfc3339 -execute "$query" | tail -n 1`
+    queryResult=`influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_EVCC_DB -username "$INFLUX_EVCC_USER" -password "$INFLUX_EVCC_PASSWORD" -precision rfc3339 -execute "$query" | tail -n 1`
     logDebug "Query result (last row): $queryResult"
     if [ `echo $queryResult | wc -w ` -eq 2 ]; then
         timestamp=`echo "$queryResult" | cut -d " " -f 1`
@@ -188,7 +191,7 @@ writeDailyEnergies() {
         energy=`echo "$queryResult" | cut -d " " -f 2`
         insertStatement="INSERT ${energyMeasurement},year=${fYear},month=${fMonth},day=${fDay} value=${energy} ${timestampNano}"
         logDebug "Insert statement: $insertStatement"
-        influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUXDB -username "$INFLUX_USER" -password "$INFLUX_PASSWORD" -execute "$insertStatement"
+        influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_AGGR_DB -username "$INFLUX_AGGR_USER" -password "$INFLUX_AGGR_PASSWORD" -execute "$insertStatement"
     else
         logInfo "There is no data from $powerMeasurement for $energyMeasurement. This may be fine, if no data had been collected for this day and this measurement."
     fi
@@ -244,7 +247,7 @@ writeMonthlyEnergies () {
     query="SELECT sum(\"$field\") FROM $dailyEnergyMeasurement WHERE ${timeCondition} tz('$TIMEZONE')"
     logDebug "Query: $query"
 
-    queryResult=`influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUXDB -username "$INFLUX_USER" -password "$INFLUX_PASSWORD" -precision rfc3339 -execute "$query" | tail -n 1`
+    queryResult=`influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_EVCC_DB -username "$INFLUX_EVCC_USER" -password "$INFLUX_EVCC_PASSWORD" -precision rfc3339 -execute "$query" | tail -n 1`
     logDebug "Query result (last row): $queryResult"
     if [ `echo $queryResult | wc -w ` -eq 2 ]; then
         timestamp=`echo "$queryResult" | cut -d " " -f 1`
@@ -252,7 +255,7 @@ writeMonthlyEnergies () {
         energy=`echo "$queryResult" | cut -d " " -f 2`
         insertStatement="INSERT ${monthlyEnergyMeasurement},year=${fYear},month=${fMonth} value=${energy} ${timestampNano}"
         logDebug "Insert statement: $insertStatement"
-        influx  -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUXDB -username "$INFLUX_USER" -password "$INFLUX_PASSWORD" -execute "$insertStatement"
+        influx  -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_AGGR_DB -username "$INFLUX_AGGR_USER" -password "$INFLUX_AGGR_PASSWORD" -execute "$insertStatement"
     else
         logInfo "There is no data from $dailyEnergyMeasurement for $monthlyEnergyMeasurement. This may be fine, if no data had been collected for this month and this measurement."
     fi    
@@ -287,7 +290,7 @@ dropMeasurement() {
     measurement=$1
     logInfo "Deleting measurement $measurement"
     dropStatement="DROP MEASUREMENT ${measurement}"
-    influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUXDB -username "$INFLUX_USER" -password "$INFLUX_PASSWORD" -execute "$dropStatement"
+    influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_AGGR_DB -username "$INFLUX_AGGR_USER" -password "$INFLUX_AGGR_PASSWORD" -execute "$dropStatement"
 }
 
 dropAggregations() {


### PR DESCRIPTION
Aggregations can be stored in a separate DB now. This allows to set up a retention policy on the real time EVCC data to clear up DB space. See https://docs.influxdata.com/influxdb/v1/query_language/manage-database/#create-retention-policies-with-create-retention-policy for more information.

Closes #16 