### PR TITLE
Fix #97: Detect and aggregate all vehicles and loadpoints

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -51,10 +51,8 @@ Statistiken über den gesamten erfassten  Datenzeitraum bestehend aus zwei Teile
 
 # Notwendige Anpassungen
 
-Jedes Dashboard hat eigene Parameter. Da es leider keine globalen Variablen in Grafana gibt, müssen diese einmal pro Dashboard angepasst werden.
-
-Gehe in die Einstellungen des Dashboards und dort auf den Tab 'Variables'. Klicke nun auf jede Variable und passe die Werte an. Du findest dort jeweils Beschreibungen, die den Parameter erklären.
-
-![Variablen Screenshot](img/variables.png)
-
-In einigen Panels werden die Bereiche für Min und Max angepasst werden müssen.
+- Jedes Dashboard hat eigene Parameter. Da es leider keine globalen Variablen in Grafana gibt, müssen diese einmal pro Dashboard während des Imports angepasst werden.
+- In einigen Panels werden die Bereiche für Min und Max angepasst werden müssen je nach maximaler Leistung von PV und Ladepunkten.
+- Je nach Anzahl der Ladepunkte und der Fahrzeuge entsprechende Panelgrößen anpassen.
+- All-time: Default Werte der Variablen, wie die Investitionskosten, anpassen.
+- Optional: Die Ladepunkte und Fahrzeuge erhalten per default alle dieselben Farben. Um für verschiedene Ladepunkte und Fahrzeuge verschiedene Farben zu erhalten müssen in den jeweiligen Panels in Grafana die Overrides angepasst werden. Es sind schon Beispiele dabei für Ladepunkte (Garage, Stellplatz) und Fahrzeuge (Ioniq 5, Tesla). Hier muss in der Regel nur das Feld auf den richtigen Ladepunkt oder das richtige Fahrzeug gemappt werden. Ansonsten müssen weitere Overrides angelegt werden. 

--- a/dashboards/dashboards/EVCC_ All-time.json
+++ b/dashboards/dashboards/EVCC_ All-time.json
@@ -24,20 +24,6 @@
       "pluginName": "InfluxDB"
     },
     {
-      "name": "VAR_VEHICLE1NAME",
-      "type": "constant",
-      "label": "Name, 1. Fahrzeug",
-      "value": "Ioniq 5",
-      "description": ""
-    },
-    {
-      "name": "VAR_VEHICLE2NAME",
-      "type": "constant",
-      "label": "Name, 2. Fahrzeug",
-      "value": "Tesla",
-      "description": ""
-    },
-    {
       "name": "VAR_SPEICHERKAPAZITAET",
       "type": "constant",
       "label": "Hausspeicherkapazität / Wh",
@@ -59,7 +45,7 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "fixedColor": "semi-dark-green",
+              "fixedColor": "orange",
               "mode": "fixed"
             },
             "mappings": [],
@@ -123,26 +109,22 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint1"
+                "options": "Garage"
               },
               "properties": [
                 {
                   "id": "color",
                   "value": {
-                    "fixedColor": "light-orange",
+                    "fixedColor": "orange",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint1Name"
                 }
               ]
             },
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint2"
+                "options": "Stellplatz"
               },
               "properties": [
                 {
@@ -151,10 +133,21 @@
                     "fixedColor": "dark-orange",
                     "mode": "fixed"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "PV"
+              },
+              "properties": [
                 {
-                  "id": "displayName",
-                  "value": "$loadpoint2Name"
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
                 }
               ]
             }
@@ -187,7 +180,7 @@
           },
           "valueMode": "text"
         },
-        "pluginVersion": "11.5.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "Netzbezug",
@@ -288,7 +281,7 @@
             "tags": []
           },
           {
-            "alias": "loadpoint1",
+            "alias": "$tag_loadpoint",
             "datasource": {
               "type": "influxdb",
               "uid": "fe8sr664fohz4a"
@@ -310,52 +303,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT sum(\"value\") /1000 from loadpoint1DailyEnergy WHERE $timeFilter tz('$timezone')",
+            "query": "SELECT sum(\"value\") /1000 from loadpointDailyEnergy WHERE $timeFilter  GROUP BY \"loadpoint\"::tag TZ('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1Energie",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "fe8sr664fohz4a"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT sum(\"value\") /1000 from loadpoint2DailyEnergy WHERE $timeFilter tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2Energie",
+            "refId": "loadpoints",
             "resultFormat": "time_series",
             "select": [
               [
@@ -499,7 +449,7 @@
             "valueSize": 16
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -633,52 +583,9 @@
             "hide": true,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT sum(\"value\") from loadpoint1DailyEnergy WHERE $timeFilter tz('$timezone')",
+            "query": "SELECT sum(\"value\")  FROM \"loadpointDailyEnergy\" WHERE $timeFilter  TZ('$timezone')",
             "rawQuery": true,
-            "refId": "energieLP1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "Loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "fe8sr664fohz4a"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": true,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT sum(\"value\") from loadpoint2DailyEnergy WHERE $timeFilter tz('$timezone')",
-            "rawQuery": true,
-            "refId": "energieLP2",
+            "refId": "energieLadepunkte",
             "resultFormat": "time_series",
             "select": [
               [
@@ -702,7 +609,7 @@
               "type": "__expr__",
               "uid": "__expr__"
             },
-            "expression": "1 - $Netzbezug/($energieHaus + $energieLP1 + $energieLP2)",
+            "expression": "1 - $Netzbezug/($energieHaus + $energieLadepunkte)",
             "hide": false,
             "refId": "Autarkie",
             "type": "math"
@@ -3098,8 +3005,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
-                "value": null
+                "color": "text"
               },
               {
                 "color": "text",
@@ -3505,8 +3411,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
-                "value": null
+                "color": "text"
               }
             ]
           },
@@ -3642,8 +3547,7 @@
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "green",
-                      "value": null
+                      "color": "green"
                     },
                     {
                       "color": "orange",
@@ -3814,52 +3718,9 @@
           "hide": true,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT sum(\"value\") from loadpoint1MonthlyEnergy WHERE $timeFilter tz('$timezone')",
+          "query": "SELECT sum(\"value\") from loadpointMonthlyEnergy WHERE $timeFilter tz('$timezone')",
           "rawQuery": true,
-          "refId": "lp1Gesamt",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT sum(\"value\") from loadpoint2MonthlyEnergy WHERE $timeFilter tz('$timezone')",
-          "rawQuery": true,
-          "refId": "lp2Gesamt",
+          "refId": "lpGesamt",
           "resultFormat": "time_series",
           "select": [
             [
@@ -3882,7 +3743,7 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "$hausverbrauchGesamt+$lp1Gesamt+$lp2Gesamt",
+          "expression": "$hausverbrauchGesamt+$lpGesamt",
           "hide": true,
           "refId": "verbrauchGesamt",
           "type": "math"
@@ -4011,6 +3872,9 @@
           "hide": false,
           "reducer": "count",
           "refId": "anzahlGemesseneTage",
+          "settings": {
+            "mode": "dropNN"
+          },
           "type": "reduce"
         },
         {
@@ -4064,8 +3928,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
-                "value": null
+                "color": "text"
               }
             ]
           },
@@ -4321,6 +4184,9 @@
           "hide": false,
           "reducer": "count",
           "refId": "anzahlGemesseneTage",
+          "settings": {
+            "mode": "dropNN"
+          },
           "type": "reduce"
         },
         {
@@ -4436,8 +4302,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4522,8 +4387,7 @@
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "red",
-                      "value": null
+                      "color": "red"
                     },
                     {
                       "color": "green",
@@ -4569,8 +4433,7 @@
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "red",
-                      "value": null
+                      "color": "red"
                     },
                     {
                       "color": "green",
@@ -4584,7 +4447,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "savingsEffectivePrice.last"
+              "options": "Effektiver, durchschnittlicher Preis"
             },
             "properties": [
               {
@@ -4626,16 +4489,40 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "vehicleConsumption"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "kW/100km"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "Geschätzter Verbrauch"
+              }
+            ]
           }
         ]
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 62
       },
       "id": 21,
+      "maxPerRow": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -4658,74 +4545,40 @@
         "wideLayout": true
       },
       "pluginVersion": "11.5.1",
+      "repeat": "vehicle",
+      "repeatDirection": "h",
       "targets": [
+        {
+          "alias": "drivenKm",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
+          },
+          "hide": false,
+          "query": "SELECT spread(\"value\") FROM \"vehicleOdometerDailyMax\" WHERE $timeFilter AND (\"vehicle\"::tag = '$vehicle') tz('$timezone')",
+          "rawQuery": true,
+          "refId": "drivenKm",
+          "resultFormat": "time_series"
+        },
         {
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
-          "groupBy": [
-            {
-              "params": [
-                "$interval"
-              ],
-              "type": "time"
-            }
-          ],
           "hide": true,
-          "measurement": "vehicle1Odometer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle1Odometer\" WHERE $timeFilter tz('$timezone')",
+          "query": "SELECT sum(\"value\")/1000 FROM \"vehicleMonthlyEnergy\" WHERE $timeFilter  AND (\"vehicle\"::tag = '$vehicle') tz('$timezone')",
           "rawQuery": true,
-          "refId": "odometer",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "min"
-              }
-            ]
-          ],
-          "tags": []
+          "refId": "chargedEnergy",
+          "resultFormat": "time_series"
         },
         {
           "datasource": {
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "odometer",
-          "hide": true,
-          "reducer": "min",
-          "refId": "startKm",
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "odometer",
-          "hide": true,
-          "reducer": "max",
-          "refId": "endKm",
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$endKm - $startKm",
+          "expression": "$chargedEnergy/($drivenKm/100)",
           "hide": false,
-          "refId": "drivenKm",
+          "refId": "vehicleConsumption",
           "type": "math"
         },
         {
@@ -4739,7 +4592,7 @@
           "measurement": "sessionSolarPercentage",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(\"value\") FROM \"sessionSolarPercentage\" WHERE $timeFilter AND (\"vehicle\"::tag = '$vehicle1Name') tz('$timezone')",
+          "query": "SELECT mean(\"value\") FROM \"sessionSolarPercentage\" WHERE $timeFilter AND (\"vehicle\"::tag = '$vehicle') tz('$timezone')",
           "rawQuery": true,
           "refId": "solarPercent",
           "resultFormat": "time_series",
@@ -4770,7 +4623,7 @@
           "measurement": "sessionPricePerKWh",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(\"value\") FROM \"sessionPricePerKWh\" WHERE $timeFilter AND (\"vehicle\"::tag = '$vehicle1Name') tz('$timezone') ",
+          "query": "SELECT mean(\"value\") FROM \"sessionPricePerKWh\" WHERE $timeFilter AND (\"vehicle\"::tag = '$vehicle') tz('$timezone') ",
           "rawQuery": true,
           "refId": "chargePrice",
           "resultFormat": "time_series",
@@ -4795,7 +4648,7 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "$drivenKm / 100 * $vehicle1Verbrauch * $stromPreis",
+          "expression": "$drivenKm / 100 * $vehicleConsumption * $stromPreis",
           "hide": false,
           "refId": "electricDriveCostNoPV",
           "type": "math"
@@ -4805,7 +4658,7 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "$drivenKm / 100 * $vehicle1Verbrauch * $chargePrice",
+          "expression": "$drivenKm / 100 * $vehicleConsumption * $chargePrice",
           "hide": false,
           "refId": "electricDriveCost",
           "type": "math"
@@ -4841,432 +4694,7 @@
           "type": "math"
         }
       ],
-      "title": "Fahrtkosten $vehicle1Name",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Mixed --"
-      },
-      "description": "Werte sind grobe Schätzungen anhand Durchschnittswerte.\n\nBerücksichtigt nicht den hier eingestellten Strompreis, sondern die Werte, die aktuellen Preise die EVCC ermittelt.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "€"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "drivenKm"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "km"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "displayName",
-                "value": "Gefahrene Kilometer"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "text",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "electricDriveCost"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Fahrtkosten  $vehicle2Name mit PV"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "iceDriveCost"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Fahrtkosten Verbrenner"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "savings"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Eingesparte Fahrtkosten ggü Verbrenner"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": null
-                    },
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "electricDriveCostNoPV"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Fahrtkosten $vehicle2Name ohne PV"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "savingsElectricPv"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Eingesparte Fahrtkosten dank PV"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": null
-                    },
-                    {
-                      "color": "green",
-                      "value": 0
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "savingsEffectivePrice.last"
-            },
-            "properties": [
-              {
-                "id": "decimals",
-                "value": 3
-              },
-              {
-                "id": "displayName",
-                "value": "Effektiver Ladepreis/kwh"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "text",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Solaranteil"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 62
-      },
-      "id": 19,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "titleSize": 12,
-          "valueSize": 20
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.5.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$interval"
-              ],
-              "type": "time"
-            }
-          ],
-          "hide": true,
-          "measurement": "vehicle1Odometer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle2Odometer\" WHERE $timeFilter tz('$timezone')",
-          "rawQuery": true,
-          "refId": "odometer",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "min"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "odometer",
-          "hide": true,
-          "reducer": "min",
-          "refId": "startKm",
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "odometer",
-          "hide": true,
-          "reducer": "max",
-          "refId": "endKm",
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$endKm - $startKm",
-          "hide": false,
-          "refId": "drivenKm",
-          "type": "math"
-        },
-        {
-          "alias": "Solaranteil",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
-          },
-          "groupBy": [],
-          "hide": false,
-          "measurement": "savingsSelfConsumptionPercent",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT mean(\"value\") FROM \"sessionSolarPercentage\" WHERE $timeFilter AND (\"vehicle\"::tag = '$vehicle2Name')  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "solarPercent",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Effektiver, durchschnittlicher Preis",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
-          },
-          "groupBy": [],
-          "hide": false,
-          "measurement": "savingsEffectivePrice",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT mean(\"value\") FROM \"sessionPricePerKWh\" WHERE $timeFilter AND (\"vehicle\"::tag = '$vehicle2Name')  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "chargePrice",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$drivenKm / 100 * $vehicle2Verbrauch * $stromPreis",
-          "hide": false,
-          "refId": "electricDriveCostNoPV",
-          "type": "math"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$drivenKm / 100 * $vehicle2Verbrauch * $chargePrice",
-          "hide": false,
-          "refId": "electricDriveCost",
-          "type": "math"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$electricDriveCostNoPV - $electricDriveCost",
-          "hide": false,
-          "refId": "savingsElectricPv",
-          "type": "math"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$drivenKm / 100 * $vVerbrauch * $spritKosten",
-          "hide": false,
-          "refId": "iceDriveCost",
-          "type": "math"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$iceDriveCost - $electricDriveCost",
-          "hide": false,
-          "refId": "savings",
-          "type": "math"
-        }
-      ],
-      "title": "Fahrtkosten $vehicle2Name",
+      "title": "Fahrtkosten $vehicle",
       "type": "stat"
     }
   ],
@@ -5377,86 +4805,6 @@
         "type": "custom"
       },
       {
-        "description": "Title des ersten Fahrzeuges, wie in der evcc.yaml definiert.",
-        "hide": 2,
-        "label": "Name, 1. Fahrzeug",
-        "name": "vehicle1Name",
-        "query": "${VAR_VEHICLE1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE1NAME}",
-          "text": "${VAR_VEHICLE1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE1NAME}",
-            "text": "${VAR_VEHICLE1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "current": {
-          "text": "20",
-          "value": "20"
-        },
-        "description": "Geschätzter durchschnittlicher Verbrauch des ersten Fahrzeuges",
-        "includeAll": false,
-        "label": "Fahrzeug 1: Verbrauch in kWh/100km",
-        "name": "vehicle1Verbrauch",
-        "options": [
-          {
-            "selected": true,
-            "text": "20",
-            "value": "20"
-          }
-        ],
-        "query": "20",
-        "type": "custom"
-      },
-      {
-        "description": "Title des zweiten Fahrzeuges, wie in der evcc.yaml definiert.",
-        "hide": 2,
-        "label": "Name, 2. Fahrzeug",
-        "name": "vehicle2Name",
-        "query": "${VAR_VEHICLE2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE2NAME}",
-          "text": "${VAR_VEHICLE2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE2NAME}",
-            "text": "${VAR_VEHICLE2NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "current": {
-          "text": "17",
-          "value": "17"
-        },
-        "description": "Geschätzter durchschnittlicher Verbrauch des zweiten Fahrzeuges",
-        "includeAll": false,
-        "label": "Fahrzeug 2: Verbrauch in kWh/100km",
-        "name": "vehicle2Verbrauch",
-        "options": [
-          {
-            "selected": true,
-            "text": "17",
-            "value": "17"
-          }
-        ],
-        "query": "17",
-        "type": "custom"
-      },
-      {
         "current": {
           "text": "6",
           "value": "6"
@@ -5530,17 +4878,39 @@
             "selected": false
           }
         ]
+      },
+      {
+        "allowCustomValue": false,
+        "current": {},
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_EVCC_AGGREGRATIONS}"
+        },
+        "definition": "show tag values from vehicleMonthlyEnergy with key = \"vehicle\"",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Fahrzeug",
+        "multi": true,
+        "name": "vehicle",
+        "options": [],
+        "query": {
+          "query": "show tag values from vehicleMonthlyEnergy with key = \"vehicle\"",
+          "refId": "InfluxVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "2023-03-01 00:00:00",
+    "from": "2023-02-28T23:00:00.000Z",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "EVCC: All-time",
   "uid": "LY-opIigz",
-  "version": 198,
+  "version": 204,
   "weekStart": ""
 }

--- a/dashboards/dashboards/EVCC_ Jahr.json
+++ b/dashboards/dashboards/EVCC_ Jahr.json
@@ -21,34 +21,6 @@
       "label": "Zeitzone",
       "value": "Europe/Berlin",
       "description": ""
-    },
-    {
-      "name": "VAR_LOADPOINT1NAME",
-      "type": "constant",
-      "label": "Name des ersten Loadpoints",
-      "value": "Garage",
-      "description": ""
-    },
-    {
-      "name": "VAR_LOADPOINT2NAME",
-      "type": "constant",
-      "label": "Name des zweiten Loadpoints",
-      "value": "Stellplatz",
-      "description": ""
-    },
-    {
-      "name": "VAR_VEHICLE1NAME",
-      "type": "constant",
-      "label": "vehicle1Name",
-      "value": "Ioniq 5",
-      "description": ""
-    },
-    {
-      "name": "VAR_VEHICLE2NAME",
-      "type": "constant",
-      "label": "vehicle2Name",
-      "value": "Tesla",
-      "description": ""
     }
   ],
   "__elements": {
@@ -65,7 +37,7 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "fixedColor": "semi-dark-green",
+              "fixedColor": "orange",
               "mode": "fixed"
             },
             "mappings": [],
@@ -129,26 +101,22 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint1"
+                "options": "Garage"
               },
               "properties": [
                 {
                   "id": "color",
                   "value": {
-                    "fixedColor": "light-orange",
+                    "fixedColor": "orange",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint1Name"
                 }
               ]
             },
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint2"
+                "options": "Stellplatz"
               },
               "properties": [
                 {
@@ -157,10 +125,21 @@
                     "fixedColor": "dark-orange",
                     "mode": "fixed"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "PV"
+              },
+              "properties": [
                 {
-                  "id": "displayName",
-                  "value": "$loadpoint2Name"
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
                 }
               ]
             }
@@ -193,7 +172,7 @@
           },
           "valueMode": "text"
         },
-        "pluginVersion": "11.5.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "Netzbezug",
@@ -294,7 +273,7 @@
             "tags": []
           },
           {
-            "alias": "loadpoint1",
+            "alias": "$tag_loadpoint",
             "datasource": {
               "type": "influxdb",
               "uid": "fe8sr664fohz4a"
@@ -316,52 +295,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT sum(\"value\") /1000 from loadpoint1DailyEnergy WHERE $timeFilter tz('$timezone')",
+            "query": "SELECT sum(\"value\") /1000 from loadpointDailyEnergy WHERE $timeFilter  GROUP BY \"loadpoint\"::tag TZ('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1Energie",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "fe8sr664fohz4a"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT sum(\"value\") /1000 from loadpoint2DailyEnergy WHERE $timeFilter tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2Energie",
+            "refId": "loadpoints",
             "resultFormat": "time_series",
             "select": [
               [
@@ -505,7 +441,7 @@
             "valueSize": 16
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -639,52 +575,9 @@
             "hide": true,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT sum(\"value\") from loadpoint1DailyEnergy WHERE $timeFilter tz('$timezone')",
+            "query": "SELECT sum(\"value\")  FROM \"loadpointDailyEnergy\" WHERE $timeFilter  TZ('$timezone')",
             "rawQuery": true,
-            "refId": "energieLP1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "Loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "fe8sr664fohz4a"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": true,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT sum(\"value\") from loadpoint2DailyEnergy WHERE $timeFilter tz('$timezone')",
-            "rawQuery": true,
-            "refId": "energieLP2",
+            "refId": "energieLadepunkte",
             "resultFormat": "time_series",
             "select": [
               [
@@ -708,7 +601,7 @@
               "type": "__expr__",
               "uid": "__expr__"
             },
-            "expression": "1 - $Netzbezug/($energieHaus + $energieLP1 + $energieLP2)",
+            "expression": "1 - $Netzbezug/($energieHaus + $energieLadepunkte)",
             "hide": false,
             "refId": "Autarkie",
             "type": "math"
@@ -1117,7 +1010,7 @@
           "colorMode": "value",
           "graphMode": "none",
           "justifyMode": "auto",
-          "orientation": "auto",
+          "orientation": "horizontal",
           "percentChangeColorMode": "standard",
           "reduceOptions": {
             "calcs": [
@@ -1134,7 +1027,7 @@
           "textMode": "auto",
           "wideLayout": true
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "Speicher laden",
@@ -1359,7 +1252,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "semi-dark-green",
+            "fixedColor": "orange",
             "mode": "fixed"
           },
           "custom": {
@@ -1416,7 +1309,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "home"
+              "options": "Haus"
             },
             "properties": [
               {
@@ -1425,36 +1318,28 @@
                   "fixedColor": "purple",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "Haus"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "loadpoint1"
+              "options": "Garage"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "light-orange",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$loadpoint1Name"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "grid"
+              "options": "Zugekauft"
             },
             "properties": [
               {
@@ -1463,17 +1348,13 @@
                   "fixedColor": "dark-yellow",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "Zugekauft"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "feedin"
+              "options": "Eingespeist"
             },
             "properties": [
               {
@@ -1482,17 +1363,13 @@
                   "fixedColor": "light-yellow",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "Eingespeist"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "loadpoint2"
+              "options": "Stellplatz"
             },
             "properties": [
               {
@@ -1501,34 +1378,25 @@
                   "fixedColor": "dark-orange",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$loadpoint2Name"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "month"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "string"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pv"
+              "options": "PV"
             },
             "properties": [
               {
                 "id": "displayName",
                 "value": "PV"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               }
             ]
           }
@@ -1558,7 +1426,7 @@
       "pluginVersion": "11.5.1",
       "targets": [
         {
-          "alias": "",
+          "alias": "PV",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -1580,10 +1448,10 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value as \"pv\" FROM \"pvMonthlyEnergy\" WHERE $timeFilter GROUP BY \"month\"::tag tz('Europe/Berlin')",
+          "query": "SELECT value as \"pv\" FROM \"pvMonthlyEnergy\" WHERE $timeFilter TZ('$timezone')",
           "rawQuery": true,
           "refId": "pvEnergy",
-          "resultFormat": "table",
+          "resultFormat": "time_series",
           "select": [
             [
               {
@@ -1601,7 +1469,7 @@
           "tags": []
         },
         {
-          "alias": "",
+          "alias": "Zugekauft",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -1623,10 +1491,10 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value as \"grid\" FROM \"gridMonthlyEnergy\" WHERE $timeFilter GROUP BY \"month\"::tag tz('Europe/Berlin')",
+          "query": "SELECT value as \"grid\" FROM \"gridMonthlyEnergy\" WHERE $timeFilter  TZ('$timezone')",
           "rawQuery": true,
           "refId": "Zugekauft",
-          "resultFormat": "table",
+          "resultFormat": "time_series",
           "select": [
             [
               {
@@ -1644,7 +1512,7 @@
           "tags": []
         },
         {
-          "alias": "",
+          "alias": "Haus",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -1666,10 +1534,10 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value * (-1)  as home FROM \"homeMonthlyEnergy\" WHERE $timeFilter GROUP BY \"month\"::tag tz('Europe/Berlin')",
+          "query": "SELECT value * (-1)  as home FROM \"homeMonthlyEnergy\" WHERE $timeFilter   TZ('$timezone')",
           "rawQuery": true,
           "refId": "Haus",
-          "resultFormat": "table",
+          "resultFormat": "time_series",
           "select": [
             [
               {
@@ -1687,7 +1555,7 @@
           "tags": []
         },
         {
-          "alias": "",
+          "alias": "$tag_loadpoint",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -1709,10 +1577,10 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value * (-1) as loadpoint1 FROM \"loadpoint1MonthlyEnergy\" WHERE $timeFilter GROUP BY \"month\"::tag tz('Europe/Berlin')",
+          "query": "SELECT value * (-1)  FROM \"loadpointMonthlyEnergy\" WHERE $timeFilter GROUP BY (\"loadpoint\"::tag)  TZ('$timezone')",
           "rawQuery": true,
-          "refId": "loadpoint1",
-          "resultFormat": "table",
+          "refId": "Ladepunkte",
+          "resultFormat": "time_series",
           "select": [
             [
               {
@@ -1730,7 +1598,7 @@
           "tags": []
         },
         {
-          "alias": "",
+          "alias": "Eingespeist",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -1752,53 +1620,10 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value * (-1) as loadpoint2 FROM \"loadpoint2MonthlyEnergy\" WHERE $timeFilter GROUP BY \"month\"::tag tz('Europe/Berlin')",
-          "rawQuery": true,
-          "refId": "loadpoint2",
-          "resultFormat": "table",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT value * (-1) as feedin FROM \"feedInMonthlyEnergy\" WHERE $timeFilter GROUP BY \"month\"::tag tz('Europe/Berlin')",
+          "query": "SELECT value * (-1) as feedin FROM \"feedInMonthlyEnergy\" WHERE $timeFilter  TZ('$timezone')",
           "rawQuery": true,
           "refId": "Eingespeist",
-          "resultFormat": "table",
+          "resultFormat": "time_series",
           "select": [
             [
               {
@@ -1911,6 +1736,18 @@
                 "value": "Eigenverbrauch"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Autarkie gridMonthlyEnergy.value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Autarkie"
+              }
+            ]
           }
         ]
       },
@@ -2001,51 +1838,9 @@
           "hide": true,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value FROM \"loadpoint1MonthlyEnergy\" WHERE $timeFilter tz('$timezone')",
+          "query": "SELECT SUM(\"last\") FROM\n(\n  SELECT last(\"value\") FROM \"loadpointMonthlyEnergy\" WHERE $timeFilter GROUP BY time(1d),\"loadpoint\"::tag tz('$timezone')\n) GROUP BY time(1d) tz('$timezone')",
           "rawQuery": true,
-          "refId": "energieLP1",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT value FROM \"loadpoint2MonthlyEnergy\" WHERE $timeFilter tz('$timezone')",
-          "rawQuery": true,
-          "refId": "energieLP2",
+          "refId": "energieLadepunkte",
           "resultFormat": "time_series",
           "select": [
             [
@@ -2110,7 +1905,7 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "1-$zugekaufteEnergie/($energieLP1+$energieLP2+$energieHaus)",
+          "expression": "1-$zugekaufteEnergie/($energieLadepunkte+$energieHaus)",
           "hide": false,
           "refId": "Autarkie",
           "type": "math"
@@ -2289,7 +2084,7 @@
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
@@ -2417,52 +2212,9 @@
           "hide": true,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value FROM \"loadpoint1DailyEnergy\" WHERE $timeFilter tz('$timezone')",
+          "query": "SELECT SUM(\"last\") FROM\n(\n  SELECT last(\"value\") FROM \"loadpointDailyEnergy\" WHERE $timeFilter GROUP BY time(1d),\"loadpoint\"::tag tz('$timezone')\n) GROUP BY time(1d) tz('$timezone')",
           "rawQuery": true,
-          "refId": "lp1Energie",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "Verbraucht/Tag",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT value FROM \"loadpoint2DailyEnergy\" WHERE $timeFilter tz('$timezone')",
-          "rawQuery": true,
-          "refId": "lp2Energie",
+          "refId": "loadpointsEnergie",
           "resultFormat": "time_series",
           "select": [
             [
@@ -2485,7 +2237,7 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "$hausEnergie+$lp1Energie+$lp2Energie",
+          "expression": "$hausEnergie+$loadpointsEnergie",
           "hide": false,
           "refId": "verbraucht",
           "type": "math"
@@ -2773,52 +2525,9 @@
           "hide": true,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"value\" FROM \"loadpoint1DailyEnergy\" WHERE $timeFilter tz('$timezone')",
+          "query": "SELECT SUM(\"last\") FROM\n(\n  SELECT last(\"value\") FROM \"loadpointDailyEnergy\" WHERE $timeFilter GROUP BY time(1d),\"loadpoint\"::tag tz('$timezone')\n) GROUP BY time(1d) tz('$timezone')",
           "rawQuery": true,
-          "refId": "lp1Energie",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"loadpoint2DailyEnergy\" WHERE $timeFilter tz('$timezone')",
-          "rawQuery": true,
-          "refId": "lp2Energie",
+          "refId": "loadpointsEnergie",
           "resultFormat": "time_series",
           "select": [
             [
@@ -2841,7 +2550,7 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "$hausEnergie+$lp1Energie+$lp2Energie",
+          "expression": "$hausEnergie+$loadpointsEnergie",
           "hide": false,
           "refId": "verbraucht",
           "type": "math"
@@ -2908,7 +2617,7 @@
     },
     {
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 4,
         "x": 0,
         "y": 37
@@ -3493,8 +3202,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3508,7 +3216,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle1Odometer"
+              "options": "Ioniq 5: Kilometerstand"
             },
             "properties": [
               {
@@ -3517,17 +3225,13 @@
                   "fixedColor": "light-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle1Name: Kilometerstand"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle2Odometer"
+              "options": "Tesla: Kilometerstand"
             },
             "properties": [
               {
@@ -3536,23 +3240,15 @@
                   "fixedColor": "dark-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle2Name: Kilometerstand"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle1DrivenKm vehicle1Odometer"
+              "options": "Ioniq 5: Gefahrene KM"
             },
             "properties": [
-              {
-                "id": "displayName",
-                "value": "$vehicle1Name: Gefahrene Strecke"
-              },
               {
                 "id": "color",
                 "value": {
@@ -3565,13 +3261,9 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle2DrivenKm vehicle2Odometer"
+              "options": "Tesla: Gefahrene KM"
             },
             "properties": [
-              {
-                "id": "displayName",
-                "value": "$vehicle2Name: Gefahrene Strecke"
-              },
               {
                 "id": "color",
                 "value": {
@@ -3603,7 +3295,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle2Consumption"
+              "options": "vehicleConsumption Tesla"
             },
             "properties": [
               {
@@ -3619,7 +3311,7 @@
               },
               {
                 "id": "displayName",
-                "value": "$vehicle2Name: Verbrauch"
+                "value": "Tesla: Verbrauch"
               }
             ]
           },
@@ -3645,7 +3337,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle1Consumption"
+              "options": "vehicleConsumption Ioniq 5"
             },
             "properties": [
               {
@@ -3661,14 +3353,14 @@
               },
               {
                 "id": "displayName",
-                "value": "$vehicle1Name: Verbrauch"
+                "value": "Ioniq 5: Verbrauch"
               }
             ]
           }
         ]
       },
       "gridPos": {
-        "h": 24,
+        "h": 16,
         "w": 4,
         "x": 0,
         "y": 57
@@ -3678,7 +3370,7 @@
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "horizontal",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
@@ -3698,141 +3390,7 @@
       "pluginVersion": "11.5.1",
       "targets": [
         {
-          "alias": "vehicle1Odometer",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "30d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "vehicle1Odometer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle1Odometer\" WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "vehicle1Odometer",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "spread"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "$vehicle1Name: Geladene Energie",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT sum(\"value\")/1000 FROM \"vehicle1MonthlyEnergy\" WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "vehicle1ChargedEnergy",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "vehicle1Odometer",
-          "hide": true,
-          "reducer": "min",
-          "refId": "startKm1",
-          "settings": {
-            "mode": "dropNN"
-          },
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "vehicle1Odometer",
-          "hide": true,
-          "reducer": "max",
-          "refId": "endKm1",
-          "settings": {
-            "mode": "dropNN"
-          },
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$endKm1-$startKm1",
-          "hide": false,
-          "refId": "vehicle1DrivenKm",
-          "type": "math"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$vehicle1ChargedEnergy/($vehicle1DrivenKm/100)",
-          "hide": false,
-          "refId": "vehicle1Consumption",
-          "type": "math"
-        },
-        {
-          "alias": "vehicle2Odometer",
+          "alias": "$tag_vehicle: Kilometerstand",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -3855,9 +3413,9 @@
           "measurement": "vehicle1Odometer",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle2Odometer\" WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT \"value\" FROM \"vehicleOdometerDailyMax\" WHERE $timeFilter GROUP BY \"vehicle\"::tag tz('$timezone')",
           "rawQuery": true,
-          "refId": "vehicle2Odometer",
+          "refId": "vehicleOdometer",
           "resultFormat": "time_series",
           "select": [
             [
@@ -3876,7 +3434,51 @@
           "tags": []
         },
         {
-          "alias": "$vehicle2Name: Geladene Energie",
+          "alias": "$tag_vehicle: Gefahrene KM",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_AGGREGRATIONS}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "30d"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "vehicle1Odometer",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT spread(\"value\") FROM \"vehicleOdometerDailyMax\" WHERE $timeFilter GROUP BY \"vehicle\"::tag tz('$timezone')",
+          "rawQuery": true,
+          "refId": "vehicleDrivenKm",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "spread"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "$tag_vehicle: Geladene Energie",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -3898,9 +3500,9 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT sum(\"value\")/1000 FROM \"vehicle2MonthlyEnergy\" WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT sum(\"value\")/1000 FROM \"vehicleMonthlyEnergy\" WHERE $timeFilter  GROUP BY \"vehicle\" tz('$timezone')",
           "rawQuery": true,
-          "refId": "vehicle2ChargedEnergy",
+          "refId": "vehicleChargedEnergy",
           "resultFormat": "time_series",
           "select": [
             [
@@ -3923,47 +3525,9 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "vehicle2Odometer",
-          "hide": true,
-          "reducer": "min",
-          "refId": "startKm2",
-          "settings": {
-            "mode": "dropNN"
-          },
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "vehicle2Odometer",
-          "hide": true,
-          "reducer": "max",
-          "refId": "endKm2",
-          "settings": {
-            "mode": "dropNN"
-          },
-          "type": "reduce"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$endKm2-$startKm2",
+          "expression": "$vehicleChargedEnergy/($vehicleDrivenKm/100)",
           "hide": false,
-          "refId": "vehicle2DrivenKm",
-          "type": "math"
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "$vehicle2ChargedEnergy/($vehicle2DrivenKm/100)",
-          "hide": false,
-          "refId": "vehicle2Consumption",
+          "refId": "vehicleConsumption",
           "type": "math"
         }
       ],
@@ -4009,8 +3573,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4024,7 +3587,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle1"
+              "options": "Ioniq 5"
             },
             "properties": [
               {
@@ -4033,17 +3596,13 @@
                   "fixedColor": "light-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle1Name"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle2"
+              "options": "Tesla"
             },
             "properties": [
               {
@@ -4052,10 +3611,6 @@
                   "fixedColor": "dark-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle2Name"
               }
             ]
           }
@@ -4093,7 +3648,7 @@
       "pluginVersion": "11.5.1",
       "targets": [
         {
-          "alias": "vehicle1",
+          "alias": "$tag_vehicle",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -4115,53 +3670,9 @@
           "measurement": "vehicle1Odometer",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle1DrivenKm\" WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT \"value\" FROM \"vehicleMonthlyDrivenKm\" WHERE $timeFilter GROUP BY \"vehicle\"::tag  tz('$timezone')",
           "rawQuery": true,
-          "refId": "vehicle1",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "spread"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "vehicle2",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "30d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "vehicle1Odometer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle2DrivenKm\" WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "vehicle2",
+          "refId": "vehicles",
           "resultFormat": "time_series",
           "select": [
             [
@@ -4220,8 +3731,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4235,7 +3745,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle1"
+              "options": "Ioniq 5"
             },
             "properties": [
               {
@@ -4244,17 +3754,13 @@
                   "fixedColor": "light-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle1Name"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle2"
+              "options": "Tesla"
             },
             "properties": [
               {
@@ -4263,10 +3769,6 @@
                   "fixedColor": "dark-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle2Name"
               }
             ]
           }
@@ -4305,7 +3807,7 @@
       "pluginVersion": "11.5.1",
       "targets": [
         {
-          "alias": "vehicle1",
+          "alias": "$tag_vehicle",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
@@ -4327,53 +3829,9 @@
           "measurement": "vehicle1Odometer",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle1MonthlyEnergy\" WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT \"value\" FROM \"vehicleMonthlyEnergy\" WHERE $timeFilter GROUP BY \"vehicle\"::tag  tz('$timezone')",
           "rawQuery": true,
-          "refId": "vehicle1",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "spread"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "vehicle2",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "30d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "vehicle1Odometer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle2MonthlyEnergy\" WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "vehicle2",
+          "refId": "vehicles",
           "resultFormat": "time_series",
           "select": [
             [
@@ -4433,8 +3891,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4447,7 +3904,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle1Consumption"
+              "options": "Verbrauch: Ioniq 5"
             },
             "properties": [
               {
@@ -4456,17 +3913,13 @@
                   "fixedColor": "light-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle1Name"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "vehicle2Consumption"
+              "options": "Verbrauch: Tesla"
             },
             "properties": [
               {
@@ -4475,10 +3928,6 @@
                   "fixedColor": "dark-red",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$vehicle2Name"
               }
             ]
           }
@@ -4540,9 +3989,9 @@
           "measurement": "vehicle1Odometer",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle1MonthlyEnergy\" WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT \"value\" FROM \"vehicleMonthlyEnergy\" WHERE $timeFilter GROUP BY \"vehicle\"::tag  tz('$timezone')",
           "rawQuery": true,
-          "refId": "vehicle1Energy",
+          "refId": "vehiclesEnergy",
           "resultFormat": "time_series",
           "select": [
             [
@@ -4584,9 +4033,9 @@
           "measurement": "vehicle1Odometer",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle1DrivenKm\" WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT \"value\" FROM \"vehicleMonthlyDrivenKm\" WHERE $timeFilter GROUP BY \"vehicle\"::tag  tz('$timezone')",
           "rawQuery": true,
-          "refId": "vehicle1Km",
+          "refId": "vehiclesKm",
           "resultFormat": "time_series",
           "select": [
             [
@@ -4609,107 +4058,9 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "($vehicle1Energy/1000)/($vehicle1Km/100)",
+          "expression": "($vehiclesEnergy/1000)/($vehiclesKm/100)",
           "hide": false,
-          "refId": "vehicle1Consumption",
-          "type": "math"
-        },
-        {
-          "alias": "",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "30d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "measurement": "vehicle1Odometer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle2MonthlyEnergy\" WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "vehicle2Energy",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "spread"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "30d"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "previous"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "measurement": "vehicle1Odometer",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT \"value\" FROM \"vehicle2DrivenKm\" WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "vehicle2Km",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "spread"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "__expr__",
-            "uid": "${DS_EXPRESSION}"
-          },
-          "expression": "($vehicle2Energy/1000)/($vehicle2Km/100)",
-          "hide": false,
-          "refId": "vehicle2Consumption",
+          "refId": "Verbrauch:",
           "type": "math"
         }
       ],
@@ -4744,88 +4095,6 @@
             "selected": false
           }
         ]
-      },
-      {
-        "description": "Name des ersten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name des ersten Loadpoints",
-        "name": "loadpoint1Name",
-        "query": "${VAR_LOADPOINT1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT1NAME}",
-          "text": "${VAR_LOADPOINT1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT1NAME}",
-            "text": "${VAR_LOADPOINT1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des zweiten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name des zweiten Loadpoints",
-        "name": "loadpoint2Name",
-        "query": "${VAR_LOADPOINT2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT2NAME}",
-          "text": "${VAR_LOADPOINT2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT2NAME}",
-            "text": "${VAR_LOADPOINT2NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des ersten Fahrzeuges wie in EVCC definiert",
-        "hide": 2,
-        "name": "vehicle1Name",
-        "query": "${VAR_VEHICLE1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE1NAME}",
-          "text": "${VAR_VEHICLE1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE1NAME}",
-            "text": "${VAR_VEHICLE1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des zweiten Fahrzeuges wie in EVCC definiert",
-        "hide": 2,
-        "name": "vehicle2Name",
-        "query": "${VAR_VEHICLE2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE2NAME}",
-          "text": "${VAR_VEHICLE2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE2NAME}",
-            "text": "${VAR_VEHICLE2NAME}",
-            "selected": false
-          }
-        ]
       }
     ]
   },
@@ -4837,6 +4106,6 @@
   "timezone": "",
   "title": "EVCC: Jahr",
   "uid": "Bdgi-xggk",
-  "version": 195,
+  "version": 206,
   "weekStart": ""
 }

--- a/dashboards/dashboards/EVCC_ Monat.json
+++ b/dashboards/dashboards/EVCC_ Monat.json
@@ -24,20 +24,6 @@
       "pluginName": "InfluxDB"
     },
     {
-      "name": "VAR_LOADPOINT1NAME",
-      "type": "constant",
-      "label": "Name, 1. Loadpoint",
-      "value": "Garage",
-      "description": ""
-    },
-    {
-      "name": "VAR_LOADPOINT2NAME",
-      "type": "constant",
-      "label": "Name, 2. Loadpoint",
-      "value": "Stellplatz",
-      "description": ""
-    },
-    {
       "name": "VAR_TIMEZONE",
       "type": "constant",
       "label": "Zeitzone",
@@ -73,7 +59,7 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "fixedColor": "semi-dark-green",
+              "fixedColor": "orange",
               "mode": "fixed"
             },
             "mappings": [],
@@ -137,26 +123,22 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint1"
+                "options": "Garage"
               },
               "properties": [
                 {
                   "id": "color",
                   "value": {
-                    "fixedColor": "light-orange",
+                    "fixedColor": "orange",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint1Name"
                 }
               ]
             },
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint2"
+                "options": "Stellplatz"
               },
               "properties": [
                 {
@@ -165,10 +147,21 @@
                     "fixedColor": "dark-orange",
                     "mode": "fixed"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "PV"
+              },
+              "properties": [
                 {
-                  "id": "displayName",
-                  "value": "$loadpoint2Name"
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
                 }
               ]
             }
@@ -201,7 +194,7 @@
           },
           "valueMode": "text"
         },
-        "pluginVersion": "11.5.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "Netzbezug",
@@ -302,7 +295,7 @@
             "tags": []
           },
           {
-            "alias": "loadpoint1",
+            "alias": "$tag_loadpoint",
             "datasource": {
               "type": "influxdb",
               "uid": "fe8sr664fohz4a"
@@ -324,52 +317,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT sum(\"value\") /1000 from loadpoint1DailyEnergy WHERE $timeFilter tz('$timezone')",
+            "query": "SELECT sum(\"value\") /1000 from loadpointDailyEnergy WHERE $timeFilter  GROUP BY \"loadpoint\"::tag TZ('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1Energie",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "fe8sr664fohz4a"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT sum(\"value\") /1000 from loadpoint2DailyEnergy WHERE $timeFilter tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2Energie",
+            "refId": "loadpoints",
             "resultFormat": "time_series",
             "select": [
               [
@@ -513,7 +463,7 @@
             "valueSize": 16
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -647,52 +597,9 @@
             "hide": true,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT sum(\"value\") from loadpoint1DailyEnergy WHERE $timeFilter tz('$timezone')",
+            "query": "SELECT sum(\"value\")  FROM \"loadpointDailyEnergy\" WHERE $timeFilter  TZ('$timezone')",
             "rawQuery": true,
-            "refId": "energieLP1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "Loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "fe8sr664fohz4a"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": true,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT sum(\"value\") from loadpoint2DailyEnergy WHERE $timeFilter tz('$timezone')",
-            "rawQuery": true,
-            "refId": "energieLP2",
+            "refId": "energieLadepunkte",
             "resultFormat": "time_series",
             "select": [
               [
@@ -716,7 +623,7 @@
               "type": "__expr__",
               "uid": "__expr__"
             },
-            "expression": "1 - $Netzbezug/($energieHaus + $energieLP1 + $energieLP2)",
+            "expression": "1 - $Netzbezug/($energieHaus + $energieLadepunkte)",
             "hide": false,
             "refId": "Autarkie",
             "type": "math"
@@ -1125,7 +1032,7 @@
           "colorMode": "value",
           "graphMode": "none",
           "justifyMode": "auto",
-          "orientation": "auto",
+          "orientation": "horizontal",
           "percentChangeColorMode": "standard",
           "reduceOptions": {
             "calcs": [
@@ -1142,7 +1049,7 @@
           "textMode": "auto",
           "wideLayout": true
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "Speicher laden",
@@ -1342,7 +1249,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "semi-dark-green",
+            "fixedColor": "orange",
             "mode": "fixed"
           },
           "custom": {
@@ -1421,7 +1328,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "loadpoint1"
+              "options": "Garage"
             },
             "properties": [
               {
@@ -1433,13 +1340,9 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "light-orange",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$loadpoint1Name"
               }
             ]
           },
@@ -1476,7 +1379,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "loadpoint2"
+              "options": "Stellplatz"
             },
             "properties": [
               {
@@ -1485,19 +1388,23 @@
                   "fixedColor": "dark-orange",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "displayName",
-                "value": "$loadpoint2Name"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": ""
+              "options": "PV"
             },
-            "properties": []
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -1622,27 +1529,15 @@
           "resultFormat": "time_series"
         },
         {
-          "alias": "loadpoint1",
+          "alias": "$tag_loadpoint",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_AGGREGRATIONS}"
           },
           "hide": false,
-          "query": "SELECT value * (-1) FROM loadpoint1DailyEnergy WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT value * (-1) FROM loadpointDailyEnergy WHERE $timeFilter GROUP BY (\"loadpoint\"::tag) tz('$timezone')",
           "rawQuery": true,
-          "refId": "loadpoint1",
-          "resultFormat": "time_series"
-        },
-        {
-          "alias": "loadpoint2",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "hide": false,
-          "query": "SELECT value * (-1) FROM loadpoint2DailyEnergy WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "loadpoint2",
+          "refId": "loadpoints",
           "resultFormat": "time_series"
         },
         {
@@ -2122,51 +2017,9 @@
           "hide": true,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT value FROM loadpoint1DailyEnergy WHERE $timeFilter  tz('$timezone')",
+          "query": "SELECT SUM(\"last\") FROM\n(\n  SELECT last(\"value\") FROM \"loadpointDailyEnergy\" WHERE $timeFilter GROUP BY time(1d),\"loadpoint\"::tag tz('$timezone')\n) GROUP BY time(1d) tz('$timezone')",
           "rawQuery": true,
-          "refId": "energieLP1",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_AGGREGRATIONS}"
-          },
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": true,
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT value FROM loadpoint2DailyEnergy WHERE $timeFilter  tz('$timezone')",
-          "rawQuery": true,
-          "refId": "energieLP2",
+          "refId": "energieLoadpoints",
           "resultFormat": "time_series",
           "select": [
             [
@@ -2231,7 +2084,7 @@
             "type": "__expr__",
             "uid": "${DS_EXPRESSION}"
           },
-          "expression": "1-$zugekaufteEnergie/($energieLP1+ $energieLP2 + $energieHaus)",
+          "expression": "1-$zugekaufteEnergie/($energieLoadpoints + $energieHaus)",
           "hide": false,
           "refId": "Autarkie",
           "type": "math"
@@ -2566,48 +2419,6 @@
   "templating": {
     "list": [
       {
-        "description": "Name des ersten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 1. Loadpoint",
-        "name": "loadpoint1Name",
-        "query": "${VAR_LOADPOINT1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT1NAME}",
-          "text": "${VAR_LOADPOINT1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT1NAME}",
-            "text": "${VAR_LOADPOINT1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des zweiten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 2. Loadpoint",
-        "name": "loadpoint2Name",
-        "query": "${VAR_LOADPOINT2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT2NAME}",
-          "text": "${VAR_LOADPOINT2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT2NAME}",
-            "text": "${VAR_LOADPOINT2NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
         "description": "Zeitzone: TZ Identifier wie hier gelistet: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List",
         "hide": 2,
         "label": "Zeitzone",
@@ -2680,6 +2491,6 @@
   "timezone": "",
   "title": "EVCC: Monat",
   "uid": "4iQda7igz",
-  "version": 179,
+  "version": 184,
   "weekStart": ""
 }

--- a/dashboards/dashboards/EVCC_ Today (Mobile).json
+++ b/dashboards/dashboards/EVCC_ Today (Mobile).json
@@ -9,34 +9,6 @@
       "pluginName": "InfluxDB"
     },
     {
-      "name": "VAR_LOADPOINT1NAME",
-      "type": "constant",
-      "label": "Name, 1. Loadpoint",
-      "value": "Garage",
-      "description": ""
-    },
-    {
-      "name": "VAR_LOADPOINT2NAME",
-      "type": "constant",
-      "label": "Name, 2. Loadpoint",
-      "value": "Stellplatz",
-      "description": ""
-    },
-    {
-      "name": "VAR_VEHICLE1NAME",
-      "type": "constant",
-      "label": "Name, 1. Fahrzeug",
-      "value": "Ioniq 5",
-      "description": ""
-    },
-    {
-      "name": "VAR_VEHICLE2NAME",
-      "type": "constant",
-      "label": "Name, 2. Fahrzeug",
-      "value": "Tesla",
-      "description": ""
-    },
-    {
       "name": "VAR_TIMEZONE",
       "type": "constant",
       "label": "Zeitzone",
@@ -73,951 +45,6 @@
     }
   ],
   "__elements": {
-    "e6a7df33-9975-455f-b748-612244c8c186": {
-      "name": "EVCC: PV/Netz Gauge",
-      "uid": "e6a7df33-9975-455f-b748-612244c8c186",
-      "kind": 1,
-      "model": {
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "neutral": 0
-            },
-            "decimals": 2,
-            "links": [],
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "#7a7a7a4d",
-                  "value": null
-                },
-                {
-                  "color": "transparent",
-                  "value": 0
-                },
-                {
-                  "color": "green",
-                  "value": 0.001
-                }
-              ]
-            },
-            "unit": "kW"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "PV"
-              },
-              "properties": [
-                {
-                  "id": "links",
-                  "value": [
-                    {
-                      "targetBlank": false,
-                      "title": "$inverterPortalTitle",
-                      "url": "$inverterPortalUrl"
-                    }
-                  ]
-                },
-                {
-                  "id": "min",
-                  "value": -11
-                },
-                {
-                  "id": "max",
-                  "value": 11
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Netz"
-              },
-              "properties": [
-                {
-                  "id": "min",
-                  "value": -12
-                },
-                {
-                  "id": "max",
-                  "value": 12
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "light-yellow",
-                        "value": null
-                      },
-                      {
-                        "color": "transparent",
-                        "value": 0
-                      },
-                      {
-                        "color": "dark-yellow",
-                        "value": 0.001
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "options": {
-          "minVizHeight": 200,
-          "minVizWidth": 138,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto",
-          "text": {
-            "titleSize": 12,
-            "valueSize": 16
-          }
-        },
-        "pluginVersion": "11.4.0",
-        "targets": [
-          {
-            "alias": "PV",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "measurement": "pvPower",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "refId": "A",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "last"
-                },
-                {
-                  "params": [
-                    " / 1000"
-                  ],
-                  "type": "math"
-                }
-              ]
-            ],
-            "tags": [],
-            "tz": "Europe/Berlin"
-          },
-          {
-            "alias": "Netz",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "hide": false,
-            "measurement": "gridPower",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "query": "SELECT mean(\"value\") FROM \"measurement\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
-            "rawQuery": false,
-            "refId": "netzleistung",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "last"
-                },
-                {
-                  "params": [
-                    " / 1000"
-                  ],
-                  "type": "math"
-                }
-              ]
-            ],
-            "tags": [],
-            "tz": "Europe/Berlin"
-          }
-        ],
-        "transparent": true,
-        "type": "gauge"
-      }
-    },
-    "f930b616-80c3-4485-98ee-0205a64c8260": {
-      "name": "EVCC: Speicher/Haus Gauge",
-      "uid": "f930b616-80c3-4485-98ee-0205a64c8260",
-      "kind": 1,
-      "model": {
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "neutral": 0
-            },
-            "decimals": 2,
-            "links": [],
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "kW"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Speicher"
-              },
-              "properties": [
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "blue",
-                        "value": null
-                      },
-                      {
-                        "color": "transparent",
-                        "value": 0
-                      },
-                      {
-                        "color": "semi-dark-blue",
-                        "value": 0.001
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "min",
-                  "value": -5
-                },
-                {
-                  "id": "max",
-                  "value": 5
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Haus"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "red",
-                    "mode": "thresholds"
-                  }
-                },
-                {
-                  "id": "links",
-                  "value": [
-                    {
-                      "targetBlank": true,
-                      "title": "SolarMan",
-                      "url": "https://globalhome.solarmanpv.com/plant/infos/data"
-                    }
-                  ]
-                },
-                {
-                  "id": "min",
-                  "value": -6
-                },
-                {
-                  "id": "max",
-                  "value": 6
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "purple",
-                        "value": null
-                      },
-                      {
-                        "color": "transparent",
-                        "value": 0
-                      },
-                      {
-                        "color": "#7a7a7a4d",
-                        "value": 0.001
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "options": {
-          "minVizHeight": 200,
-          "minVizWidth": 200,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto",
-          "text": {
-            "titleSize": 12,
-            "valueSize": 16
-          }
-        },
-        "pluginVersion": "11.3.0",
-        "targets": [
-          {
-            "alias": "Speicher",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "hide": false,
-            "measurement": "batteryPower",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "refId": "Speicher",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [
-                    " / 1000"
-                  ],
-                  "type": "math"
-                }
-              ]
-            ],
-            "tags": [],
-            "tz": "Europe/Berlin"
-          },
-          {
-            "alias": "Haus",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "hide": false,
-            "measurement": "homePower",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "query": "SELECT mean(\"value\") FROM \"measurement\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
-            "rawQuery": false,
-            "refId": "Haus",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [
-                    "*(-1)/1000"
-                  ],
-                  "type": "math"
-                }
-              ]
-            ],
-            "tags": [],
-            "tz": "Europe/Berlin"
-          }
-        ],
-        "transparent": true,
-        "type": "gauge"
-      }
-    },
-    "fad84f15-41e1-4f01-9ad1-f8c3a02bfaac": {
-      "name": "EVCC: Ladepunkte Gauge",
-      "uid": "fad84f15-41e1-4f01-9ad1-f8c3a02bfaac",
-      "kind": 1,
-      "model": {
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "neutral": 0
-            },
-            "decimals": 2,
-            "links": [],
-            "mappings": [],
-            "max": 11,
-            "min": -11,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "kW"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "loadpoint1"
-              },
-              "properties": [
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "light-orange",
-                        "value": null
-                      },
-                      {
-                        "color": "transparent",
-                        "value": 0
-                      },
-                      {
-                        "color": "#7a7a7a4d",
-                        "value": 0.001
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint1Name"
-                },
-                {
-                  "id": "links",
-                  "value": [
-                    {
-                      "title": "EVCC: $loadpoint1Name",
-                      "url": "$evccUrl?lp=1"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "loadpoint2"
-              },
-              "properties": [
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "dark-orange",
-                        "value": null
-                      },
-                      {
-                        "color": "transparent",
-                        "value": 0
-                      },
-                      {
-                        "color": "#7a7a7a4d",
-                        "value": 0.001
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint2Name"
-                },
-                {
-                  "id": "links",
-                  "value": [
-                    {
-                      "title": "EVCC: $loadpoint2Name",
-                      "url": "$evccUrl?lp=2"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "options": {
-          "minVizHeight": 200,
-          "minVizWidth": 200,
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "sizing": "auto",
-          "text": {
-            "titleSize": 12,
-            "valueSize": 16
-          }
-        },
-        "pluginVersion": "11.5.0",
-        "targets": [
-          {
-            "alias": "loadpoint1",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "hide": false,
-            "measurement": "chargePower",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "query": "SELECT \"value\" *(-1)/1000 FROM \"autogen\".\"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter tz('Europe/Berlin')",
-            "rawQuery": true,
-            "refId": "loadpoint1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [
-                    "*(-1)/1000"
-                  ],
-                  "type": "math"
-                }
-              ]
-            ],
-            "tags": [
-              {
-                "key": "loadpoint::tag",
-                "operator": "=",
-                "value": "Garage"
-              }
-            ],
-            "tz": "Europe/Berlin"
-          },
-          {
-            "alias": "loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "hide": false,
-            "measurement": "chargePower",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "query": "SELECT \"value\" *(-1)/1000 FROM \"autogen\".\"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter tz('Europe/Berlin')",
-            "rawQuery": true,
-            "refId": "loadpoint2",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [
-                    "*(-1)/1000"
-                  ],
-                  "type": "math"
-                }
-              ]
-            ],
-            "tags": [
-              {
-                "key": "loadpoint::tag",
-                "operator": "=",
-                "value": "Stellplatz"
-              }
-            ],
-            "tz": "Europe/Berlin"
-          }
-        ],
-        "transparent": true,
-        "type": "gauge"
-      }
-    },
-    "bel91qRRz": {
-      "name": "EVCC: Batteriestände",
-      "uid": "bel91qRRz",
-      "kind": 1,
-      "model": {
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_EVCC_INFLUXDB}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "blue",
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "links": [
-              {
-                "title": "Gehe zu EVCC",
-                "url": "http://home:7070/#/"
-              }
-            ],
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "red",
-                  "value": null
-                },
-                {
-                  "color": "orange",
-                  "value": 20
-                },
-                {
-                  "color": "yellow",
-                  "value": 50
-                },
-                {
-                  "color": "green",
-                  "value": 70
-                },
-                {
-                  "color": "dark-orange",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Speicher"
-              },
-              "properties": [
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "blue",
-                        "value": null
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "vehicle1Soc"
-              },
-              "properties": [
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "light-red",
-                        "value": null
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle1Name"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "vehicle2Soc"
-              },
-              "properties": [
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "dark-red",
-                        "value": null
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle2Name"
-                }
-              ]
-            }
-          ]
-        },
-        "options": {
-          "displayMode": "basic",
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "maxVizHeight": 300,
-          "minVizHeight": 16,
-          "minVizWidth": 8,
-          "namePlacement": "top",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": true,
-          "sizing": "auto",
-          "valueMode": "color"
-        },
-        "pluginVersion": "11.4.0",
-        "targets": [
-          {
-            "alias": "Speicher",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "10s"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "previous"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "measurement": "batterySoc",
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT last(\"value\") FROM \"batterySoc\" WHERE $timeFilter GROUP BY time(10s) fill(previous) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "socHome",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "last"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "vehicle1Soc",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "10s"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "previous"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "measurement": "vehicleSoc",
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT last(\"value\") FROM \"vehicleSoc\" WHERE (\"vehicle\"::tag = '$vehicle1Name') AND $timeFilter GROUP BY time(10s) fill(previous) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "vehicle1Soc",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "last"
-                }
-              ]
-            ],
-            "tags": [
-              {
-                "key": "vehicle::tag",
-                "operator": "=~",
-                "value": "/^$vehicle1Name$/"
-              }
-            ]
-          },
-          {
-            "alias": "vehicle2Soc",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "10s"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "previous"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "measurement": "vehicleSoc",
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT last(\"value\") FROM \"vehicleSoc\" WHERE (\"vehicle\"::tag = '$vehicle2Name') AND $timeFilter GROUP BY time(10s) fill(previous) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "vehicle2Soc",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "last"
-                }
-              ]
-            ],
-            "tags": [
-              {
-                "key": "vehicle::tag",
-                "operator": "=~",
-                "value": "/^$vehicle2Name$/"
-              }
-            ]
-          }
-        ],
-        "title": "Batteriestände",
-        "transparent": true,
-        "type": "bargauge"
-      }
-    },
     "rswX1qRRz": {
       "name": "EVCC: PV Verbrauchsverlauf",
       "uid": "rswX1qRRz",
@@ -1031,7 +58,8 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "palette-classic"
+              "fixedColor": "orange",
+              "mode": "fixed"
             },
             "custom": {
               "axisBorderShow": false,
@@ -1138,7 +166,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint1"
+                "options": "Garage"
               },
               "properties": [
                 {
@@ -1147,10 +175,6 @@
                     "fixedColor": "light-orange",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint1Name"
                 }
               ]
             },
@@ -1172,7 +196,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint2"
+                "options": "Stellplatz"
               },
               "properties": [
                 {
@@ -1181,10 +205,6 @@
                     "fixedColor": "dark-orange",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint2Name"
                 }
               ]
             }
@@ -1199,11 +219,12 @@
             "showLegend": true
           },
           "tooltip": {
+            "hideZeros": false,
             "mode": "multi",
             "sort": "none"
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -1291,49 +312,6 @@
             "tags": []
           },
           {
-            "alias": "Speicher",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT max(\"value\") FROM \"batteryPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "Batterieleistung",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
@@ -1377,7 +355,7 @@
             "tags": []
           },
           {
-            "alias": "loadpoint1",
+            "alias": "Speicher",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -1399,9 +377,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "query": "SELECT max(\"value\") FROM \"batteryPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "Laden Garage",
+            "refId": "Batterieleistung",
             "resultFormat": "time_series",
             "select": [
               [
@@ -1420,7 +398,7 @@
             "tags": []
           },
           {
-            "alias": "loadpoint2",
+            "alias": "$tag_loadpoint",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -1442,9 +420,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE $timeFilter GROUP BY time(1m), \"loadpoint\"::tag fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "Laden Stellplatz",
+            "refId": "Loadpoint",
             "resultFormat": "time_series",
             "select": [
               [
@@ -1479,7 +457,8 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "palette-classic"
+              "fixedColor": "orange",
+              "mode": "fixed"
             },
             "custom": {
               "axisBorderShow": false,
@@ -1530,7 +509,7 @@
                 }
               ]
             },
-            "unit": "none"
+            "unit": "watt"
           },
           "overrides": [
             {
@@ -1539,10 +518,6 @@
                 "options": "PV"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -1559,10 +534,6 @@
               },
               "properties": [
                 {
-                  "id": "unit",
-                  "value": "watt"
-                },
-                {
                   "id": "color",
                   "value": {
                     "fixedColor": "purple",
@@ -1577,10 +548,6 @@
                 "options": "Einspeisung"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -1597,10 +564,6 @@
               },
               "properties": [
                 {
-                  "id": "unit",
-                  "value": "watt"
-                },
-                {
                   "id": "color",
                   "value": {
                     "fixedColor": "yellow",
@@ -1612,13 +575,9 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint1"
+                "options": "Garage"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -1638,10 +597,6 @@
                 "options": "Speicher laden"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -1673,13 +628,9 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint2"
+                "options": "Stellplatz"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -1712,11 +663,12 @@
             "showLegend": false
           },
           "tooltip": {
+            "hideZeros": false,
             "mode": "multi",
             "sort": "none"
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -1740,6 +692,7 @@
             ],
             "hide": false,
             "orderByTime": "ASC",
+            "policy": "default",
             "query": "SELECT max(\"value\") FROM \"pvPower\" WHERE (\"value\"::field < $peakPowerLimit) AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "PV Leistung",
@@ -1782,6 +735,7 @@
             ],
             "hide": true,
             "orderByTime": "ASC",
+            "policy": "default",
             "query": "SELECT max(\"value\") FROM \"gridPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "netzleistung",
@@ -1825,6 +779,49 @@
             "type": "math"
           },
           {
+            "alias": "Haus",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "L-nZgczgk"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT max(\"value\") * (-1) FROM \"homePower\" WHERE (\"value\"::field < $peakPowerLimit) AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "rawQuery": true,
+            "refId": "Hausverbrauch",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": []
+          },
+          {
             "alias": "Batterieleistung",
             "datasource": {
               "type": "influxdb",
@@ -1846,6 +843,7 @@
             ],
             "hide": true,
             "orderByTime": "ASC",
+            "policy": "default",
             "query": "SELECT max(\"value\") *(-1) FROM \"batteryPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "batterieleistung",
@@ -1889,7 +887,7 @@
             "type": "math"
           },
           {
-            "alias": "loadpoint1",
+            "alias": "$tag_loadpoint",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -1911,94 +909,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE $timeFilter GROUP BY time(1m), \"loadpoint\"::tag fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "Haus",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "query": "SELECT max(\"value\") * (-1) FROM \"homePower\" WHERE (\"value\"::field < $peakPowerLimit) AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "Hausverbrauch",
+            "refId": "loadpoints",
             "resultFormat": "time_series",
             "select": [
               [
@@ -2034,7 +947,8 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "palette-classic"
+              "fixedColor": "red",
+              "mode": "fixed"
             },
             "custom": {
               "axisBorderShow": false,
@@ -2122,7 +1036,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle2"
+                "options": "Tesla"
               },
               "properties": [
                 {
@@ -2131,17 +1045,13 @@
                     "fixedColor": "dark-red",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle2Name"
                 }
               ]
             },
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle1"
+                "options": "Ioniq 5"
               },
               "properties": [
                 {
@@ -2150,10 +1060,6 @@
                     "fixedColor": "light-red",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle1Name"
                 }
               ]
             },
@@ -2187,7 +1093,7 @@
             "sort": "none"
           }
         },
-        "pluginVersion": "11.5.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "Speicher",
@@ -2213,7 +1119,7 @@
             "measurement": "batterySoc",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") FROM \"batterySoc\" WHERE $timeFilter and value <= 100 GROUP BY time(5m) fill(none) tz('Europe/Berlin')",
+            "query": "SELECT max(\"value\") FROM \"batterySoc\" WHERE $timeFilter and value <= 100 GROUP BY time(5m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "Speicher",
             "resultFormat": "time_series",
@@ -2234,7 +1140,7 @@
             "tags": []
           },
           {
-            "alias": "vehicle1",
+            "alias": "$tag_vehicle",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -2244,36 +1150,9 @@
             "measurement": "vehicleSoc",
             "orderByTime": "ASC",
             "policy": "autogen",
-            "query": "SELECT max(\"value\") FROM \"vehicleSoc\" WHERE (\"vehicle\"::tag = '$vehicle1Name') AND $timeFilter GROUP BY time(5m) fill(none) tz('Europe/Berlin')",
+            "query": "SELECT max(\"value\") FROM \"vehicleSoc\" WHERE $timeFilter AND (\"vehicle\"::tag <> '')  GROUP BY time(5m), \"vehicle\"::tag fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "vehicle1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "vehicle2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "hide": false,
-            "measurement": "vehicleSoc",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "query": "SELECT max(\"value\") FROM \"vehicleSoc\" WHERE (\"vehicle\"::tag = '$vehicle2Name') AND $timeFilter GROUP BY time(5m) fill(none) tz('Europe/Berlin')",
-            "rawQuery": true,
-            "refId": "vehicle2",
+            "refId": "vehicles",
             "resultFormat": "time_series",
             "select": [
               [
@@ -2466,7 +1345,7 @@
           "type": "influxdb",
           "uid": "${DS_EVCC_INFLUXDB}"
         },
-        "description": "",
+        "description": "Autarkie muss durch die Summe der Haus Energie und die Summe der einzelnen Loadpoints geteilt werden.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -2563,7 +1442,7 @@
             "titleSize": 12
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "",
@@ -2759,52 +1638,9 @@
             "hide": true,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter GROUP BY time(1d) fill(none) tz('$timezone')",
+            "query": "SELECT SUM(\"integral\") FROM\n(\n  SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE $timeFilter GROUP BY time(1d), \"loadpoint\"::tag fill(none) tz('$timezone')\n) GROUP BY time(1d) tz('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": true,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter GROUP BY time(1d) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2",
+            "refId": "energieLadepunkte",
             "resultFormat": "time_series",
             "select": [
               [
@@ -2828,7 +1664,7 @@
               "type": "__expr__",
               "uid": "__expr__"
             },
-            "expression": "1 - $Netzbezug/($energieHaus + $loadpoint1 + $loadpoint2)",
+            "expression": "1 - $Netzbezug/($energieHaus+$energieLadepunkte)",
             "hide": false,
             "refId": "Autarkie",
             "type": "math"
@@ -3006,12 +1842,13 @@
             "showLegend": false
           },
           "tooltip": {
+            "hideZeros": false,
             "maxHeight": 600,
             "mode": "multi",
             "sort": "none"
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "netzbezug",
@@ -3078,51 +1915,9 @@
             "hide": true,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint1Name') AND  $timeFilter GROUP BY time(15m) fill(0) tz('$timezone')",
+            "query": "SELECT SUM(\"integral\") FROM\n(\n  SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE $timeFilter GROUP BY time(15m), \"loadpoint\"::tag fill(none) tz('$timezone')\n) GROUP BY time(15m) tz('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": true,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint2Name') AND  $timeFilter GROUP BY time(15m) fill(0) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2",
+            "refId": "loadpoints",
             "resultFormat": "time_series",
             "select": [
               [
@@ -3188,7 +1983,7 @@
               "type": "__expr__",
               "uid": "__expr__"
             },
-            "expression": "1-$netzbezug/($loadpoint1+$loadpoint2+$energieHaus)",
+            "expression": "1-$netzbezug/($loadpoints+$energieHaus)",
             "hide": false,
             "refId": "Autarkie",
             "type": "math"
@@ -3306,7 +2101,7 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "fixedColor": "semi-dark-green",
+              "fixedColor": "red",
               "mode": "fixed"
             },
             "custom": {
@@ -3394,7 +2189,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle2"
+                "options": "Tesla"
               },
               "properties": [
                 {
@@ -3403,10 +2198,6 @@
                     "fixedColor": "dark-red",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle2Name"
                 }
               ]
             },
@@ -3462,19 +2253,30 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle1"
+                "options": "Ioniq 5"
               },
               "properties": [
                 {
                   "id": "color",
                   "value": {
                     "fixedColor": "light-red",
-                    "mode": "shades"
+                    "mode": "fixed"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "PV"
+              },
+              "properties": [
                 {
-                  "id": "displayName",
-                  "value": "$vehicle1Name"
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
                 }
               ]
             }
@@ -3498,6 +2300,7 @@
             "valueSize": 20
           },
           "tooltip": {
+            "hideZeros": false,
             "mode": "single",
             "sort": "none"
           },
@@ -3505,7 +2308,7 @@
           "xTickLabelRotation": 0,
           "xTickLabelSpacing": 0
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -3637,6 +2440,49 @@
             "tags": []
           },
           {
+            "alias": "Haus",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "L-nZgczgk"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT integral(\"value\") /-3600000 FROM \"homePower\" WHERE $timeFilter and value < $peakPowerLimit GROUP BY time(1d) fill(null)  tz('$timezone')",
+            "rawQuery": true,
+            "refId": "energyHome",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": []
+          },
+          {
             "alias": "Speicher laden",
             "datasource": {
               "type": "influxdb",
@@ -3723,7 +2569,7 @@
             "tags": []
           },
           {
-            "alias": "Haus",
+            "alias": "$tag_vehicle",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -3745,95 +2591,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT integral(\"value\") /-3600000 FROM \"homePower\" WHERE $timeFilter and value < $peakPowerLimit GROUP BY time(1d) fill(null)  tz('$timezone')",
+            "query": "SELECT integral(\"value\")  / -3600000 FROM \"chargePower\" WHERE (\"vehicle\"::tag <> '') AND $timeFilter GROUP BY time(1d), \"vehicle\"::tag fill(0) tz('$timezone') ",
             "rawQuery": true,
-            "refId": "energyHome",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "vehicle1",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / -3600000 FROM \"chargePower\" WHERE (\"vehicle\"::tag = '$vehicle1Name')  AND $timeFilter GROUP BY time(1d) fill(0) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "vehicle1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "vehicle2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / -3600000 FROM \"chargePower\" WHERE (\"vehicle\"::tag = '$vehicle2Name') AND $timeFilter GROUP BY time(1d) fill(null) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "vehicle2",
+            "refId": "vehicles",
             "resultFormat": "time_series",
             "select": [
               [
@@ -3907,7 +2667,6 @@
             "resultFormat": "time_series"
           }
         ],
-        "title": "Energie (kWh)",
         "transformations": [
           {
             "id": "reduce",
@@ -3942,6 +2701,12 @@
   },
   "__requires": [
     {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
@@ -3952,6 +2717,12 @@
       "id": "influxdb",
       "name": "InfluxDB",
       "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
     }
   ],
   "annotations": {
@@ -4060,56 +2831,677 @@
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_EVCC_INFLUXDB}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "links": [],
+          "mappings": [],
+          "max": 11,
+          "min": -11,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "transparent",
+                "value": 0
+              },
+              {
+                "color": "#7a7a7a4d",
+                "value": 122.12212203
+              }
+            ]
+          },
+          "unit": "kW"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PV"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "$inverterPortalTitle",
+                    "url": "$inverterPortalUrl"
+                  }
+                ]
+              },
+              {
+                "id": "min",
+                "value": -11
+              },
+              {
+                "id": "max",
+                "value": 11
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.001
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Netz"
+            },
+            "properties": [
+              {
+                "id": "min",
+                "value": -12
+              },
+              {
+                "id": "max",
+                "value": 12
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-yellow",
+                      "value": null
+                    },
+                    {
+                      "color": "transparent",
+                      "value": 0
+                    },
+                    {
+                      "color": "dark-yellow",
+                      "value": 0.001
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Speicher"
+            },
+            "properties": [
+              {
+                "id": "min",
+                "value": -5
+              },
+              {
+                "id": "max",
+                "value": 5
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "blue",
+                      "value": null
+                    },
+                    {
+                      "color": "transparent",
+                      "value": 0
+                    },
+                    {
+                      "color": "blue",
+                      "value": 0.001
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Haus"
+            },
+            "properties": [
+              {
+                "id": "min",
+                "value": -6
+              },
+              {
+                "id": "max",
+                "value": 6
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "purple",
+                      "value": null
+                    },
+                    {
+                      "color": "#7a7a7a4d",
+                      "value": 0
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Garage"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "light-orange",
+                      "value": null
+                    },
+                    {
+                      "color": "transparent",
+                      "value": 0
+                    },
+                    {
+                      "color": "#7a7a7a4d",
+                      "value": 0.001
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "EVCC: $loadpoint1Name",
+                    "url": "$evccUrl?lp=1"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Stellplatz"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "semi-dark-orange",
+                      "value": null
+                    },
+                    {
+                      "color": "transparent",
+                      "value": 0
+                    },
+                    {
+                      "color": "#7a7a7a4d",
+                      "value": 0.001
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "EVCC: $loadpoint2Name",
+                    "url": "$evccUrl?lp=2"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
-        "h": 5,
+        "h": 7,
         "w": 24,
         "x": 0,
         "y": 1
       },
-      "id": 68,
-      "libraryPanel": {
-        "uid": "e6a7df33-9975-455f-b748-612244c8c186",
-        "name": "EVCC: PV/Netz Gauge"
-      }
-    },
-    {
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 6
+      "id": 73,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 10,
+          "valueSize": 20
+        },
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "id": 70,
-      "libraryPanel": {
-        "uid": "f930b616-80c3-4485-98ee-0205a64c8260",
-        "name": "EVCC: Speicher/Haus Gauge"
-      }
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "alias": "PV",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "groupBy": [],
+          "measurement": "pvPower",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT last(\"value\")  / 1000 FROM \"autogen\".\"pvPower\" WHERE $timeFilter tz('$timezone')",
+          "rawQuery": true,
+          "refId": "PV",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [
+                  " / 1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [],
+          "tz": "Europe/Berlin"
+        },
+        {
+          "alias": "Netz",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "groupBy": [],
+          "hide": false,
+          "measurement": "gridPower",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT last(\"value\")  / 1000 FROM \"autogen\".\"gridPower\" WHERE $timeFilter tz('$timezone')",
+          "rawQuery": true,
+          "refId": "netzleistung",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [
+                  " / 1000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [],
+          "tz": "Europe/Berlin"
+        },
+        {
+          "alias": "Haus",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "hide": false,
+          "query": "SELECT \"value\" *(-1)/1000 FROM \"autogen\".\"homePower\" WHERE $timeFilter tz('$timezone')",
+          "rawQuery": true,
+          "refId": "Haus",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "Speicher",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "hide": false,
+          "query": "SELECT \"value\"  / 1000 FROM \"autogen\".\"batteryPower\" WHERE $timeFilter tz('$timezone')",
+          "rawQuery": true,
+          "refId": "Speicher",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "$tag_loadpoint",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "loadpoint::tag"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "chargePower",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"value\")\n*(-1)/1000 FROM \"chargePower\" WHERE $timeFilter GROUP BY time($__interval), \"loadpoint\"::tag fill(null)",
+          "rawQuery": true,
+          "refId": "Loadpoints",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
     },
     {
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 11
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_EVCC_INFLUXDB}"
       },
-      "id": 69,
-      "libraryPanel": {
-        "uid": "fad84f15-41e1-4f01-9ad1-f8c3a02bfaac",
-        "name": "EVCC: Ladepunkte Gauge"
-      }
-    },
-    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "links": [
+            {
+              "title": "Gehe zu EVCC",
+              "url": "http://home:7070/#/"
+            }
+          ],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 20
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 70
+              },
+              {
+                "color": "dark-orange",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Speicher"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Ioniq 5"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tesla"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 8
       },
       "id": 71,
-      "libraryPanel": {
-        "uid": "bel91qRRz",
-        "name": "EVCC: Batteriestände"
-      }
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "top",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {
+          "titleSize": 12
+        },
+        "valueMode": "hidden"
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "alias": "Speicher",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "10s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "batterySoc",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"batterySoc\" WHERE $timeFilter GROUP BY time(10s) fill(previous) tz('$timezone')",
+          "rawQuery": true,
+          "refId": "socHome",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "$tag_vehicle",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "10s"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "vehicleSoc",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT max(\"value\") FROM \"vehicleSoc\" WHERE $timeFilter AND (\"vehicle\"::tag <> '')  GROUP BY time(5m), \"vehicle\"::tag fill(none) tz('$timezone')",
+          "rawQuery": true,
+          "refId": "vehicles",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "vehicle::tag",
+              "operator": "=~",
+              "value": "/^$vehicle1Name$/"
+            }
+          ]
+        }
+      ],
+      "title": "Batteriestände",
+      "transparent": true,
+      "type": "bargauge"
     },
     {
       "collapsed": false,
@@ -4117,7 +3509,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 12
       },
       "id": 37,
       "panels": [],
@@ -4129,7 +3521,7 @@
         "h": 18,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 13
       },
       "id": 43,
       "libraryPanel": {
@@ -4142,7 +3534,7 @@
         "h": 2,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 31
       },
       "id": 53,
       "libraryPanel": {
@@ -4155,7 +3547,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 33
       },
       "id": 67,
       "libraryPanel": {
@@ -4168,7 +3560,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 39
       },
       "id": 72,
       "libraryPanel": {
@@ -4182,7 +3574,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 44
       },
       "id": 35,
       "panels": [],
@@ -4194,7 +3586,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 45
       },
       "id": 65,
       "libraryPanel": {
@@ -4207,7 +3599,7 @@
         "h": 2,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 50
       },
       "id": 57,
       "libraryPanel": {
@@ -4220,7 +3612,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 52
       },
       "id": 18,
       "libraryPanel": {
@@ -4236,90 +3628,6 @@
   ],
   "templating": {
     "list": [
-      {
-        "description": "Name des ersten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 1. Loadpoint",
-        "name": "loadpoint1Name",
-        "query": "${VAR_LOADPOINT1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT1NAME}",
-          "text": "${VAR_LOADPOINT1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT1NAME}",
-            "text": "${VAR_LOADPOINT1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des ersten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 2. Loadpoint",
-        "name": "loadpoint2Name",
-        "query": "${VAR_LOADPOINT2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT2NAME}",
-          "text": "${VAR_LOADPOINT2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT2NAME}",
-            "text": "${VAR_LOADPOINT2NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des ersten Fahrzeuges, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 1. Fahrzeug",
-        "name": "vehicle1Name",
-        "query": "${VAR_VEHICLE1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE1NAME}",
-          "text": "${VAR_VEHICLE1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE1NAME}",
-            "text": "${VAR_VEHICLE1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des zweiten Fahrzeuges, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 2. Fahrzeug",
-        "name": "vehicle2Name",
-        "query": "${VAR_VEHICLE2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE2NAME}",
-          "text": "${VAR_VEHICLE2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE2NAME}",
-            "text": "${VAR_VEHICLE2NAME}",
-            "selected": false
-          }
-        ]
-      },
       {
         "description": "Zeitzone: TZ Identifier wie hier gelistet: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List",
         "hide": 2,
@@ -4441,6 +3749,6 @@
   "timezone": "",
   "title": "EVCC: Today (Mobile)",
   "uid": "MRHnynkRz",
-  "version": 91,
+  "version": 123,
   "weekStart": ""
 }

--- a/dashboards/dashboards/EVCC_ Today.json
+++ b/dashboards/dashboards/EVCC_ Today.json
@@ -9,34 +9,6 @@
       "pluginName": "InfluxDB"
     },
     {
-      "name": "VAR_LOADPOINT1NAME",
-      "type": "constant",
-      "label": "Name, 1. Loadpoint",
-      "value": "Garage",
-      "description": ""
-    },
-    {
-      "name": "VAR_LOADPOINT2NAME",
-      "type": "constant",
-      "label": "Name, 2. Loadpoint",
-      "value": "Stellplatz",
-      "description": ""
-    },
-    {
-      "name": "VAR_VEHICLE1NAME",
-      "type": "constant",
-      "label": "Name, 1. Fahrzeug",
-      "value": "Ioniq 5",
-      "description": ""
-    },
-    {
-      "name": "VAR_VEHICLE2NAME",
-      "type": "constant",
-      "label": "Name, 2. Fahrzeug",
-      "value": "Tesla",
-      "description": ""
-    },
-    {
       "name": "VAR_TIMEZONE",
       "type": "constant",
       "label": "Zeitzone",
@@ -86,7 +58,8 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "palette-classic"
+              "fixedColor": "orange",
+              "mode": "fixed"
             },
             "custom": {
               "axisBorderShow": false,
@@ -193,7 +166,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint1"
+                "options": "Garage"
               },
               "properties": [
                 {
@@ -202,10 +175,6 @@
                     "fixedColor": "light-orange",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint1Name"
                 }
               ]
             },
@@ -227,7 +196,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint2"
+                "options": "Stellplatz"
               },
               "properties": [
                 {
@@ -236,10 +205,6 @@
                     "fixedColor": "dark-orange",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$loadpoint2Name"
                 }
               ]
             }
@@ -254,11 +219,12 @@
             "showLegend": true
           },
           "tooltip": {
+            "hideZeros": false,
             "mode": "multi",
             "sort": "none"
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -346,49 +312,6 @@
             "tags": []
           },
           {
-            "alias": "Speicher",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT max(\"value\") FROM \"batteryPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "Batterieleistung",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
             "alias": "Haus",
             "datasource": {
               "type": "influxdb",
@@ -432,7 +355,7 @@
             "tags": []
           },
           {
-            "alias": "loadpoint1",
+            "alias": "Speicher",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -454,9 +377,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "query": "SELECT max(\"value\") FROM \"batteryPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "Laden Garage",
+            "refId": "Batterieleistung",
             "resultFormat": "time_series",
             "select": [
               [
@@ -475,7 +398,7 @@
             "tags": []
           },
           {
-            "alias": "loadpoint2",
+            "alias": "$tag_loadpoint",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -497,9 +420,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE $timeFilter GROUP BY time(1m), \"loadpoint\"::tag fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "Laden Stellplatz",
+            "refId": "Loadpoint",
             "resultFormat": "time_series",
             "select": [
               [
@@ -534,7 +457,8 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "palette-classic"
+              "fixedColor": "red",
+              "mode": "fixed"
             },
             "custom": {
               "axisBorderShow": false,
@@ -622,7 +546,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle2"
+                "options": "Tesla"
               },
               "properties": [
                 {
@@ -631,17 +555,13 @@
                     "fixedColor": "dark-red",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle2Name"
                 }
               ]
             },
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle1"
+                "options": "Ioniq 5"
               },
               "properties": [
                 {
@@ -650,10 +570,6 @@
                     "fixedColor": "light-red",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle1Name"
                 }
               ]
             },
@@ -687,7 +603,7 @@
             "sort": "none"
           }
         },
-        "pluginVersion": "11.5.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "Speicher",
@@ -713,7 +629,7 @@
             "measurement": "batterySoc",
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") FROM \"batterySoc\" WHERE $timeFilter and value <= 100 GROUP BY time(5m) fill(none) tz('Europe/Berlin')",
+            "query": "SELECT max(\"value\") FROM \"batterySoc\" WHERE $timeFilter and value <= 100 GROUP BY time(5m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "Speicher",
             "resultFormat": "time_series",
@@ -734,7 +650,7 @@
             "tags": []
           },
           {
-            "alias": "vehicle1",
+            "alias": "$tag_vehicle",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -744,36 +660,9 @@
             "measurement": "vehicleSoc",
             "orderByTime": "ASC",
             "policy": "autogen",
-            "query": "SELECT max(\"value\") FROM \"vehicleSoc\" WHERE (\"vehicle\"::tag = '$vehicle1Name') AND $timeFilter GROUP BY time(5m) fill(none) tz('Europe/Berlin')",
+            "query": "SELECT max(\"value\") FROM \"vehicleSoc\" WHERE $timeFilter AND (\"vehicle\"::tag <> '')  GROUP BY time(5m), \"vehicle\"::tag fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "vehicle1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "vehicle2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [],
-            "hide": false,
-            "measurement": "vehicleSoc",
-            "orderByTime": "ASC",
-            "policy": "autogen",
-            "query": "SELECT max(\"value\") FROM \"vehicleSoc\" WHERE (\"vehicle\"::tag = '$vehicle2Name') AND $timeFilter GROUP BY time(5m) fill(none) tz('Europe/Berlin')",
-            "rawQuery": true,
-            "refId": "vehicle2",
+            "refId": "vehicles",
             "resultFormat": "time_series",
             "select": [
               [
@@ -966,7 +855,7 @@
           "type": "influxdb",
           "uid": "${DS_EVCC_INFLUXDB}"
         },
-        "description": "",
+        "description": "Autarkie muss durch die Summe der Haus Energie und die Summe der einzelnen Loadpoints geteilt werden.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -1063,7 +952,7 @@
             "titleSize": 12
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "",
@@ -1259,52 +1148,9 @@
             "hide": true,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter GROUP BY time(1d) fill(none) tz('$timezone')",
+            "query": "SELECT SUM(\"integral\") FROM\n(\n  SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE $timeFilter GROUP BY time(1d), \"loadpoint\"::tag fill(none) tz('$timezone')\n) GROUP BY time(1d) tz('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": true,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter GROUP BY time(1d) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2",
+            "refId": "energieLadepunkte",
             "resultFormat": "time_series",
             "select": [
               [
@@ -1328,7 +1174,7 @@
               "type": "__expr__",
               "uid": "__expr__"
             },
-            "expression": "1 - $Netzbezug/($energieHaus + $loadpoint1 + $loadpoint2)",
+            "expression": "1 - $Netzbezug/($energieHaus+$energieLadepunkte)",
             "hide": false,
             "refId": "Autarkie",
             "type": "math"
@@ -1506,12 +1352,13 @@
             "showLegend": false
           },
           "tooltip": {
+            "hideZeros": false,
             "maxHeight": 600,
             "mode": "multi",
             "sort": "none"
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "netzbezug",
@@ -1578,51 +1425,9 @@
             "hide": true,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint1Name') AND  $timeFilter GROUP BY time(15m) fill(0) tz('$timezone')",
+            "query": "SELECT SUM(\"integral\") FROM\n(\n  SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE $timeFilter GROUP BY time(15m), \"loadpoint\"::tag fill(none) tz('$timezone')\n) GROUP BY time(15m) tz('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": true,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / 3600 FROM \"chargePower\" WHERE(\"loadpoint\"::tag = '$loadpoint2Name') AND  $timeFilter GROUP BY time(15m) fill(0) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2",
+            "refId": "loadpoints",
             "resultFormat": "time_series",
             "select": [
               [
@@ -1688,7 +1493,7 @@
               "type": "__expr__",
               "uid": "__expr__"
             },
-            "expression": "1-$netzbezug/($loadpoint1+$loadpoint2+$energieHaus)",
+            "expression": "1-$netzbezug/($loadpoints+$energieHaus)",
             "hide": false,
             "refId": "Autarkie",
             "type": "math"
@@ -1806,7 +1611,7 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "fixedColor": "semi-dark-green",
+              "fixedColor": "red",
               "mode": "fixed"
             },
             "custom": {
@@ -1894,7 +1699,7 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle2"
+                "options": "Tesla"
               },
               "properties": [
                 {
@@ -1903,10 +1708,6 @@
                     "fixedColor": "dark-red",
                     "mode": "fixed"
                   }
-                },
-                {
-                  "id": "displayName",
-                  "value": "$vehicle2Name"
                 }
               ]
             },
@@ -1962,19 +1763,30 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "vehicle1"
+                "options": "Ioniq 5"
               },
               "properties": [
                 {
                   "id": "color",
                   "value": {
                     "fixedColor": "light-red",
-                    "mode": "shades"
+                    "mode": "fixed"
                   }
-                },
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "PV"
+              },
+              "properties": [
                 {
-                  "id": "displayName",
-                  "value": "$vehicle1Name"
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
                 }
               ]
             }
@@ -1998,6 +1810,7 @@
             "valueSize": 20
           },
           "tooltip": {
+            "hideZeros": false,
             "mode": "single",
             "sort": "none"
           },
@@ -2005,7 +1818,7 @@
           "xTickLabelRotation": 0,
           "xTickLabelSpacing": 0
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -2137,6 +1950,49 @@
             "tags": []
           },
           {
+            "alias": "Haus",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "L-nZgczgk"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT integral(\"value\") /-3600000 FROM \"homePower\" WHERE $timeFilter and value < $peakPowerLimit GROUP BY time(1d) fill(null)  tz('$timezone')",
+            "rawQuery": true,
+            "refId": "energyHome",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": []
+          },
+          {
             "alias": "Speicher laden",
             "datasource": {
               "type": "influxdb",
@@ -2223,7 +2079,7 @@
             "tags": []
           },
           {
-            "alias": "Haus",
+            "alias": "$tag_vehicle",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -2245,95 +2101,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT integral(\"value\") /-3600000 FROM \"homePower\" WHERE $timeFilter and value < $peakPowerLimit GROUP BY time(1d) fill(null)  tz('$timezone')",
+            "query": "SELECT integral(\"value\")  / -3600000 FROM \"chargePower\" WHERE (\"vehicle\"::tag <> '') AND $timeFilter GROUP BY time(1d), \"vehicle\"::tag fill(0) tz('$timezone') ",
             "rawQuery": true,
-            "refId": "energyHome",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "vehicle1",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / -3600000 FROM \"chargePower\" WHERE (\"vehicle\"::tag = '$vehicle1Name')  AND $timeFilter GROUP BY time(1d) fill(0) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "vehicle1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "vehicle2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT integral(\"value\")  / -3600000 FROM \"chargePower\" WHERE (\"vehicle\"::tag = '$vehicle2Name') AND $timeFilter GROUP BY time(1d) fill(null) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "vehicle2",
+            "refId": "vehicles",
             "resultFormat": "time_series",
             "select": [
               [
@@ -2407,7 +2177,6 @@
             "resultFormat": "time_series"
           }
         ],
-        "title": "Energie (kWh)",
         "transformations": [
           {
             "id": "reduce",
@@ -2452,7 +2221,8 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "palette-classic"
+              "fixedColor": "orange",
+              "mode": "fixed"
             },
             "custom": {
               "axisBorderShow": false,
@@ -2503,7 +2273,7 @@
                 }
               ]
             },
-            "unit": "none"
+            "unit": "watt"
           },
           "overrides": [
             {
@@ -2512,10 +2282,6 @@
                 "options": "PV"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -2532,10 +2298,6 @@
               },
               "properties": [
                 {
-                  "id": "unit",
-                  "value": "watt"
-                },
-                {
                   "id": "color",
                   "value": {
                     "fixedColor": "purple",
@@ -2550,10 +2312,6 @@
                 "options": "Einspeisung"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -2570,10 +2328,6 @@
               },
               "properties": [
                 {
-                  "id": "unit",
-                  "value": "watt"
-                },
-                {
                   "id": "color",
                   "value": {
                     "fixedColor": "yellow",
@@ -2585,13 +2339,9 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint1"
+                "options": "Garage"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -2611,10 +2361,6 @@
                 "options": "Speicher laden"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -2646,13 +2392,9 @@
             {
               "matcher": {
                 "id": "byName",
-                "options": "loadpoint2"
+                "options": "Stellplatz"
               },
               "properties": [
-                {
-                  "id": "unit",
-                  "value": "watt"
-                },
                 {
                   "id": "color",
                   "value": {
@@ -2685,11 +2427,12 @@
             "showLegend": false
           },
           "tooltip": {
+            "hideZeros": false,
             "mode": "multi",
             "sort": "none"
           }
         },
-        "pluginVersion": "11.4.0",
+        "pluginVersion": "11.5.1",
         "targets": [
           {
             "alias": "PV",
@@ -2713,6 +2456,7 @@
             ],
             "hide": false,
             "orderByTime": "ASC",
+            "policy": "default",
             "query": "SELECT max(\"value\") FROM \"pvPower\" WHERE (\"value\"::field < $peakPowerLimit) AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "PV Leistung",
@@ -2755,6 +2499,7 @@
             ],
             "hide": true,
             "orderByTime": "ASC",
+            "policy": "default",
             "query": "SELECT max(\"value\") FROM \"gridPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "netzleistung",
@@ -2798,6 +2543,49 @@
             "type": "math"
           },
           {
+            "alias": "Haus",
+            "datasource": {
+              "type": "influxdb",
+              "uid": "L-nZgczgk"
+            },
+            "groupBy": [
+              {
+                "params": [
+                  "$__interval"
+                ],
+                "type": "time"
+              },
+              {
+                "params": [
+                  "null"
+                ],
+                "type": "fill"
+              }
+            ],
+            "hide": false,
+            "orderByTime": "ASC",
+            "policy": "default",
+            "query": "SELECT max(\"value\") * (-1) FROM \"homePower\" WHERE (\"value\"::field < $peakPowerLimit) AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "rawQuery": true,
+            "refId": "Hausverbrauch",
+            "resultFormat": "time_series",
+            "select": [
+              [
+                {
+                  "params": [
+                    "value"
+                  ],
+                  "type": "field"
+                },
+                {
+                  "params": [],
+                  "type": "mean"
+                }
+              ]
+            ],
+            "tags": []
+          },
+          {
             "alias": "Batterieleistung",
             "datasource": {
               "type": "influxdb",
@@ -2819,6 +2607,7 @@
             ],
             "hide": true,
             "orderByTime": "ASC",
+            "policy": "default",
             "query": "SELECT max(\"value\") *(-1) FROM \"batteryPower\" WHERE $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
             "rawQuery": true,
             "refId": "batterieleistung",
@@ -2862,7 +2651,7 @@
             "type": "math"
           },
           {
-            "alias": "loadpoint1",
+            "alias": "$tag_loadpoint",
             "datasource": {
               "type": "influxdb",
               "uid": "L-nZgczgk"
@@ -2884,94 +2673,9 @@
             "hide": false,
             "orderByTime": "ASC",
             "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
+            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE $timeFilter GROUP BY time(1m), \"loadpoint\"::tag fill(none) tz('$timezone')",
             "rawQuery": true,
-            "refId": "loadpoint1",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "loadpoint2",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "policy": "default",
-            "query": "SELECT max(\"value\") * (-1) FROM \"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "loadpoint2",
-            "resultFormat": "time_series",
-            "select": [
-              [
-                {
-                  "params": [
-                    "value"
-                  ],
-                  "type": "field"
-                },
-                {
-                  "params": [],
-                  "type": "mean"
-                }
-              ]
-            ],
-            "tags": []
-          },
-          {
-            "alias": "Haus",
-            "datasource": {
-              "type": "influxdb",
-              "uid": "L-nZgczgk"
-            },
-            "groupBy": [
-              {
-                "params": [
-                  "$__interval"
-                ],
-                "type": "time"
-              },
-              {
-                "params": [
-                  "null"
-                ],
-                "type": "fill"
-              }
-            ],
-            "hide": false,
-            "orderByTime": "ASC",
-            "query": "SELECT max(\"value\") * (-1) FROM \"homePower\" WHERE (\"value\"::field < $peakPowerLimit) AND $timeFilter GROUP BY time(1m) fill(none) tz('$timezone')",
-            "rawQuery": true,
-            "refId": "Hausverbrauch",
+            "refId": "loadpoints",
             "resultFormat": "time_series",
             "select": [
               [
@@ -3136,11 +2840,13 @@
           "decimals": 2,
           "links": [],
           "mappings": [],
+          "max": 11,
+          "min": -11,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "#7a7a7a4d",
+                "color": "orange",
                 "value": null
               },
               {
@@ -3148,8 +2854,8 @@
                 "value": 0
               },
               {
-                "color": "green",
-                "value": 0.001
+                "color": "#7a7a7a4d",
+                "value": 122.12212203
               }
             ]
           },
@@ -3179,6 +2885,22 @@
               {
                 "id": "max",
                 "value": 11
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.001
+                    }
+                  ]
+                }
               }
             ]
           },
@@ -3289,17 +3011,9 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "loadpoint1"
+              "options": "Garage"
             },
             "properties": [
-              {
-                "id": "min",
-                "value": -11
-              },
-              {
-                "id": "max",
-                "value": 11
-              },
               {
                 "id": "thresholds",
                 "value": {
@@ -3328,27 +3042,15 @@
                     "url": "$evccUrl?lp=1"
                   }
                 ]
-              },
-              {
-                "id": "displayName",
-                "value": "$loadpoint1Name"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "loadpoint2"
+              "options": "Stellplatz"
             },
             "properties": [
-              {
-                "id": "min",
-                "value": -11
-              },
-              {
-                "id": "max",
-                "value": 11
-              },
               {
                 "id": "thresholds",
                 "value": {
@@ -3377,10 +3079,6 @@
                     "url": "$evccUrl?lp=2"
                   }
                 ]
-              },
-              {
-                "id": "displayName",
-                "value": "$loadpoint2Name"
               }
             ]
           }
@@ -3490,18 +3188,6 @@
           "tz": "Europe/Berlin"
         },
         {
-          "alias": "Speicher",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
-          },
-          "hide": false,
-          "query": "SELECT \"value\"  / 1000 FROM \"autogen\".\"batteryPower\" WHERE $timeFilter tz('$timezone')",
-          "rawQuery": true,
-          "refId": "Speicher",
-          "resultFormat": "time_series"
-        },
-        {
           "alias": "Haus",
           "datasource": {
             "type": "influxdb",
@@ -3514,7 +3200,19 @@
           "resultFormat": "time_series"
         },
         {
-          "alias": "loadpoint1",
+          "alias": "Speicher",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_EVCC_INFLUXDB}"
+          },
+          "hide": false,
+          "query": "SELECT \"value\"  / 1000 FROM \"autogen\".\"batteryPower\" WHERE $timeFilter tz('$timezone')",
+          "rawQuery": true,
+          "refId": "Speicher",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "$tag_loadpoint",
           "datasource": {
             "type": "influxdb",
             "uid": "${DS_EVCC_INFLUXDB}"
@@ -3528,17 +3226,24 @@
             },
             {
               "params": [
+                "loadpoint::tag"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
                 "null"
               ],
               "type": "fill"
             }
           ],
           "hide": false,
+          "measurement": "chargePower",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT \"value\" *(-1)/1000 FROM \"autogen\".\"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint1Name') AND $timeFilter tz('$timezone')",
+          "query": "SELECT mean(\"value\")\n*(-1)/1000 FROM \"chargePower\" WHERE $timeFilter GROUP BY time($__interval), \"loadpoint\"::tag fill(null)",
           "rawQuery": true,
-          "refId": "Garage",
+          "refId": "Loadpoints",
           "resultFormat": "time_series",
           "select": [
             [
@@ -3555,18 +3260,6 @@
             ]
           ],
           "tags": []
-        },
-        {
-          "alias": "loadpoint2",
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_EVCC_INFLUXDB}"
-          },
-          "hide": false,
-          "query": "SELECT \"value\" *(-1)/1000 FROM \"autogen\".\"chargePower\" WHERE (\"loadpoint\"::tag = '$loadpoint2Name') AND $timeFilter tz('$timezone')",
-          "rawQuery": true,
-          "refId": "Stellplatz",
-          "resultFormat": "time_series"
         }
       ],
       "transparent": true,
@@ -3671,90 +3364,6 @@
   ],
   "templating": {
     "list": [
-      {
-        "description": "Name des ersten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 1. Loadpoint",
-        "name": "loadpoint1Name",
-        "query": "${VAR_LOADPOINT1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT1NAME}",
-          "text": "${VAR_LOADPOINT1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT1NAME}",
-            "text": "${VAR_LOADPOINT1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des zweiten Loadpoints, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 2. Loadpoint",
-        "name": "loadpoint2Name",
-        "query": "${VAR_LOADPOINT2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_LOADPOINT2NAME}",
-          "text": "${VAR_LOADPOINT2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_LOADPOINT2NAME}",
-            "text": "${VAR_LOADPOINT2NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des ersten Fahrzeuges, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 1. Fahrzeug",
-        "name": "vehicle1Name",
-        "query": "${VAR_VEHICLE1NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE1NAME}",
-          "text": "${VAR_VEHICLE1NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE1NAME}",
-            "text": "${VAR_VEHICLE1NAME}",
-            "selected": false
-          }
-        ]
-      },
-      {
-        "description": "Name des zweiten Fahrzeuges, wie in EVCC definiert.",
-        "hide": 2,
-        "label": "Name, 2. Fahrzeug",
-        "name": "vehicle2Name",
-        "query": "${VAR_VEHICLE2NAME}",
-        "skipUrlSync": true,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VEHICLE2NAME}",
-          "text": "${VAR_VEHICLE2NAME}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VEHICLE2NAME}",
-            "text": "${VAR_VEHICLE2NAME}",
-            "selected": false
-          }
-        ]
-      },
       {
         "description": "Zeitzone: TZ Identifier wie hier gelistet: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List",
         "hide": 2,
@@ -3870,6 +3479,6 @@
   "timezone": "",
   "title": "EVCC: Today",
   "uid": "7Ou-Y1Rgk",
-  "version": 167,
+  "version": 175,
   "weekStart": ""
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 Irgendwann war der Raspberry PI heillos damit überfordert alle Daten live zusammenzustellen und die monatlichen und vorallem jährlichen Dashboards liefen nur noch in Timeouts. Daher war eine Aggregierung notwendig. Diese erledigt das Bash Shell Script `evcc-influx-aggregate.sh`.
 
-# Installation
+## Installation
 
 1. Script [`evcc-influx-aggregate.sh`](./evcc-influx-aggregate.sh) und Konfigurationsdatei [`evcc-influx-aggregate.conf`](./evcc-influx-aggregate.conf) herunterladen und auf ein Linux System kopieren. Idealerweise ist dies das System (oder die VM) auf der die InfluxDB läuft. Falls dies nicht möglicht ist (z.B. HAOS), kann das script auch remote von einem anderen Linux System ausgeführt werden.
 
@@ -31,13 +31,19 @@ Irgendwann war der Raspberry PI heillos damit überfordert alle Daten live zusam
 
 5. Die Recht für das Script anpassen, damit es ausführbar wird: `chmod +x evcc-influx-aggregate.sh`
 
-6. Für jedes Jahr, für das die Influx DB bereits mit EVCC Daten gefüllt ist, eine Aggregierung des gesamten Jahres starten:
+6. Einmal die Fahrzeuge und Ladepunkte erkennen lassen:
    ```bash
-   ./evcc-influx-aggregate.sh --year 2024
+   ./evcc-influx-aggregate.sh --detect
+   ```
+   Überprüfen ob die Namen der Fahrzeuge und Ladepunkte stimmen.
+
+7. Für jedes Jahr, für das die Influx DB bereits mit EVCC Daten gefüllt ist, eine Aggregierung des gesamten Jahres starten:
+   ```bash
+   ./evcc-influx-aggregate.sh --year 2025
    ```
    Das wird nun etwas dauern.
 
-7. Mit Hilfe von `crontab -e` folgende regelmäßige Aufrufe konfigurieren:
+8. Mit Hilfe von `crontab -e` folgende regelmäßige Aufrufe konfigurieren:
    ```
    5 0 * * * <PATH_TO_SCRIPT>/evcc-influx-aggregate.sh --yesterday >> /var/log/evcc-grafana-dashboards.log 2>&1
    0 * * * * <PATH_TO_SCRIPT>/evcc-influx-aggregate.sh --today >> /var/log/evcc-grafana-dashboards.log 2>&1
@@ -46,7 +52,7 @@ Irgendwann war der Raspberry PI heillos damit überfordert alle Daten live zusam
 
    Damit wird dann jede Nacht der gestrige Tage aggregiert, sowie jede volle Stunde einmal der aktuelle Tag. Die Ausgaben werden in der Datei `/var/log/evcc-grafana-dashboards.log` geloggt.
 
-8. Anlegen und Setzen der permissions des Log Files:
+9. Anlegen und Setzen der permissions des Log Files:
    ```bash
    sudo touch /var/log/evcc-grafana-dashboards.log
    sudo chown <USERNAME> /var/log/evcc-grafana-dashboards.log
@@ -54,3 +60,27 @@ Irgendwann war der Raspberry PI heillos damit überfordert alle Daten live zusam
    Dabei ist `<USERNAME>` durch den Loginnamen des Benutzers zu ersetzen unter dem in Schritt 8 der Befehl `crontab -e` ausgeführt wurde.
 
 
+## Benutzung
+
+| Parameter                    | Beschreibung                                                                             |
+| ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `--day <year> <month> <day>` | Aggregiere die Daten für den angegebenen Tag und den Monat                               |
+| `--month <year> <month>`     | Aggegriere alle Daten für alle Tage dem dem angegebenen Monat.                           |
+| `--year <year>`              | Aggegriere alle Daten für alle Tage und Monate des angegebenen Jahres                    |
+| `--today`                    | Aggregiere die Daten des heutigen Tages und des aktuellen Monats                         |
+| `--yesterday`                | Aggregiere die Daten des gestrigen Tages und des gestrigen Monats                        |
+| `--delete-aggregations`      | Lösche die Measurements der aggregierten Daten aus der Influx Datenbank. Das Löschen eines Measurements kann durchaus einige Zeit benötigen. |
+| `--detect`                   | Suche die Loadpoints und Vehicles aus der Datenbank heraus. Es ist empfehlenswert dies einmal vor der ersten Aggregation auszuführen, um zu überprüfen ob die Namen der Loadpoints und Vehicles stimmen.|
+
+
+### Beispiele
+
+Aggregiere die Daten aller Tage des Jahres 2024:
+```bash
+evcc-influx-aggregate.sh --year 2024
+```
+
+Aggregiere die Daten vom 16.7.2024:
+```bash
+evcc-influx-aggregate.sh --day 2024 7 16
+```

--- a/scripts/evcc-influx-aggregate.conf
+++ b/scripts/evcc-influx-aggregate.conf
@@ -28,31 +28,13 @@ INFLUX_HOST="localhost"
 INFLUX_PORT=8086 
 
 
-### PV, BATTERY, LOADPOINT AND VEHICLE CONFIGURATION ###
+### PV CONFIGURATION ###
 
 # Limit in W to filter out unrealistic peaks. Default: 40000
 PEAK_POWER_LIMIT=40000 
 
 # Set to false in case your home does not use a battery.
 HOME_BATTERY="true"
-
-# Title of loadpoint 1 as defined in evcc.yaml
-LOADPOINT_1_TITLE="Garage" 
-
-# Set to false in case you have just one loadpoint
-LOADPOINT_2_ENABLED=true 
-
-# Title of loadpoint 2 as defined in evcc.yaml
-LOADPOINT_2_TITLE="Stellplatz" 
-
-# Title of vehicle 1 as defined in evcc.yaml
-VEHICLE_1_TITLE="Ioniq 5" 
-
-# Set to false in case you have just one vehicle
-VEHICLE_2_ENABLED=true 
-
-# Title of vehicle 2 as defined in evcc.yaml
-VEHICLE_2_TITLE="Tesla" 
 
 # Set to true to collect tariff history.
 DYNAMIC_TARIFF="true" 

--- a/scripts/evcc-influx-aggregate.sh
+++ b/scripts/evcc-influx-aggregate.sh
@@ -38,6 +38,7 @@ AGGREGATE_DAY_YEAR=0
 AGGREGATE_DAY_MONTH=0
 AGGREGATE_DAY_DAY=0
 DELETE_AGGREGATIONS=false
+DETECT_VALUES=false
 
 # Maps of number of days per month. February leap year is updated later
 declare -A DAYS_OF_MONTH
@@ -53,6 +54,12 @@ DAYS_OF_MONTH[9]=30
 DAYS_OF_MONTH[10]=31
 DAYS_OF_MONTH[11]=30
 DAYS_OF_MONTH[12]=31
+
+# Array of vehicles
+declare -A VEHICLES
+
+#Array of loadpoints
+declare -A LOADPOINTS
 
 parseArguments() {
     if [ "$#" -eq 0 ]; then
@@ -104,12 +111,17 @@ parseArguments() {
         logDebug "Deleting aggregations."
         return 0
     fi
+    if [ "$1" == '--detect' ]; then
+        DETECT_VALUES=true
+        logDebug "Detecting loadpoints and vehicles."
+        return 0
+    fi
     printUsage
     exit 1
 }
 
 printUsage() {
-    echo "`basename $0` [--year <year> | --month <year> <month> | --day <year> <month> <day> | --yesterday | --today | --delete-aggregations]"
+    echo "`basename $0` [--year <year> | --month <year> <month> | --day <year> <month> <day> | --today | --yesterday | --delete-aggregations | --detect]"
 }
 
 isLeapYear() {
@@ -140,6 +152,7 @@ writeDailyAggregations() {
     day=$7
     additionalWhere=$8
     defaultZero=$9
+    additionalTags=${10}
 
     printf -v fYear "%04d" $year
     printf -v fMonth "%02d" $month
@@ -193,7 +206,11 @@ writeDailyAggregations() {
         logInfo "There is no data from $sourceMeasurement for $targetMeasurement."
     fi
     if [ "$energy" != "0" ] || [ "$defaultZero" == "true" ]; then
-        insertStatement="INSERT ${targetMeasurement},year=${fYear},month=${fMonth},day=${fDay} value=${energy} ${timestamp}"
+        if [ "$additionalTags" != "" ]; then
+            insertStatement="INSERT ${targetMeasurement},year=${fYear},month=${fMonth},day=${fDay},${additionalTags} value=${energy} ${timestamp}"
+        else
+            insertStatement="INSERT ${targetMeasurement},year=${fYear},month=${fMonth},day=${fDay} value=${energy} ${timestamp}"
+        fi
         logDebug "Insert statement: $insertStatement"
         influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_AGGR_DB -username "$INFLUX_AGGR_USER" -password "$INFLUX_AGGR_PASSWORD" -execute "$insertStatement"
     fi
@@ -211,21 +228,21 @@ aggregateDay() {
     writeDailyAggregations "integral-positives" "value" "gridPower" "gridDailyEnergy" $ayear $amonth $aday "AND value < $PEAK_POWER_LIMIT" "true"
     writeDailyAggregations "integral-negatives" "value" "gridPower" "feedInDailyEnergy" $ayear $amonth $aday "AND value < $PEAK_POWER_LIMIT" "true"
 
-    writeDailyAggregations "integral-all" "value" "chargePower" "loadpoint1DailyEnergy" $ayear $amonth $aday "AND ("loadpoint"::tag = '${LOADPOINT_1_TITLE}') AND value < $PEAK_POWER_LIMIT" "true"
-    if [ "$LOADPOINT_2_ENABLED" == "true" ]; then
-        writeDailyAggregations "integral-all" "value" "chargePower" "loadpoint2DailyEnergy" $ayear $amonth $aday "AND ("loadpoint"::tag = '${LOADPOINT_2_TITLE}') AND value < $PEAK_POWER_LIMIT" "true"
-    else
-        logDebug "Loadpoint 2 is disabled."
-    fi
+    # writeDailyAggregations "integral-all" "value" "chargePower" "loadpoint1DailyEnergy" $ayear $amonth $aday "AND ("loadpoint"::tag = '${LOADPOINT_1_TITLE}') AND value < $PEAK_POWER_LIMIT" "true"
+    # if [ "$LOADPOINT_2_ENABLED" == "true" ]; then
+    #     writeDailyAggregations "integral-all" "value" "chargePower" "loadpoint2DailyEnergy" $ayear $amonth $aday "AND ("loadpoint"::tag = '${LOADPOINT_2_TITLE}') AND value < $PEAK_POWER_LIMIT" "true"
+    # else
+    #     logDebug "Loadpoint 2 is disabled."
+    # fi
 
-    writeDailyAggregations "max" "value" "vehicleOdometer" "vehicle1Odometer" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_1_TITLE}')" "false"
-    writeDailyAggregations "integral-positives" "value" "chargePower" "vehicle1DailyEnergy" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_1_TITLE}') AND value < $PEAK_POWER_LIMIT" "true" # Workaround: Integral does not work for vehicle as there are too few data points
-    if [ "$VEHICLE_2_ENABLED" == "true" ]; then
-        writeDailyAggregations "max" "value" "vehicleOdometer" "vehicle2Odometer" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_2_TITLE}')" "false"
-        writeDailyAggregations "integral-positives" "value" "chargePower" "vehicle2DailyEnergy" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_2_TITLE}') AND value < $PEAK_POWER_LIMIT" "true" # Workaround: Integral does not work for vehicle as there are too few data points
-    else
-        logDebug "Vehicle 2 is disabled."
-    fi
+    # writeDailyAggregations "max" "value" "vehicleOdometer" "vehicle1Odometer" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_1_TITLE}')" "false"
+    # writeDailyAggregations "integral-positives" "value" "chargePower" "vehicle1DailyEnergy" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_1_TITLE}') AND value < $PEAK_POWER_LIMIT" "true" # Workaround: Integral does not work for vehicle as there are too few data points
+    # if [ "$VEHICLE_2_ENABLED" == "true" ]; then
+    #     writeDailyAggregations "max" "value" "vehicleOdometer" "vehicle2Odometer" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_2_TITLE}')" "false"
+    #     writeDailyAggregations "integral-positives" "value" "chargePower" "vehicle2DailyEnergy" $ayear $amonth $aday "AND ("vehicle"::tag = '${VEHICLE_2_TITLE}') AND value < $PEAK_POWER_LIMIT" "true" # Workaround: Integral does not work for vehicle as there are too few data points
+    # else
+    #     logDebug "Vehicle 2 is disabled."
+    # fi
 
     if [ "$HOME_BATTERY" == "true" ]; then
         writeDailyAggregations "integral-positives" "value" "batteryPower" "dischargeDailyEnergy" $ayear $amonth $aday "AND value < $PEAK_POWER_LIMIT" "true"
@@ -243,6 +260,19 @@ aggregateDay() {
     else
         logDebug "Dynamic tariff aggregation is disabled."
     fi
+
+    for vehicle in "${VEHICLES[@]}"; do
+        logDebug "Aggregating vehicle $vehicle"
+        escapedVehicle=$(echo $vehicle | sed 's/ /\\ /g')
+        writeDailyAggregations "max" "value" "vehicleOdometer" "vehicleOdometerDailyMax" $ayear $amonth $aday "AND \"vehicle\"::tag = '${vehicle}'" "false" "vehicle=${escapedVehicle}"
+        writeDailyAggregations "integral-positives" "value" "chargePower" "vehicleDailyEnergy" $ayear $amonth $aday "AND \"vehicle\"::tag = '${vehicle}' AND value < $PEAK_POWER_LIMIT" "true" "vehicle=${escapedVehicle}"
+    done
+
+    for loadpoint in "${LOADPOINTS[@]}"; do
+        logDebug "Aggregating loadpoint $loadpoint"
+        escapedLoadpoint=$(echo $loadpoint | sed 's/ /\\ /g')
+        writeDailyAggregations "integral-all" "value" "chargePower" "loadpointDailyEnergy" $ayear $amonth $aday "AND \"loadpoint\"::tag = '${loadpoint}' AND value < $PEAK_POWER_LIMIT" "true" "loadpoint=${escapedLoadpoint}"
+    done
 }
 
 writeMonthlyAggregations () {
@@ -252,6 +282,8 @@ writeMonthlyAggregations () {
     monthlytargetMeasurement=$4
     year=$5
     month=$6
+    additionalWhere=$7
+    additionalTags=$8
 
     numDays=${DAYS_OF_MONTH[$month]}
 
@@ -266,7 +298,11 @@ writeMonthlyAggregations () {
 
     logDebug "${fYear}-${fMonth}: Creating monthly aggregation from $dailytargetMeasurement into ${monthlytargetMeasurement}"
     logDebug "Month has $numDays days."
-    query="SELECT $aggregation(\"$field\") FROM $dailytargetMeasurement WHERE ${timeCondition} tz('$TIMEZONE')"
+    if [ "$additionalWhere" != "" ]; then
+        query="SELECT $aggregation(\"$field\") FROM $dailytargetMeasurement WHERE ${timeCondition} ${additionalWhere} tz('$TIMEZONE')"
+    else
+        query="SELECT $aggregation(\"$field\") FROM $dailytargetMeasurement WHERE ${timeCondition} tz('$TIMEZONE')"
+    fi
     logDebug "Query: $query"
 
     queryResult=`influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_AGGR_DB -username "$INFLUX_AGGR_USER" -password "$INFLUX_AGGR_PASSWORD" -precision rfc3339 -execute "$query" | tail -n 1`
@@ -277,8 +313,12 @@ writeMonthlyAggregations () {
         energy=`echo "$queryResult" | cut -d " " -f 2`
     else
         logInfo "There is no data from $dailytargetMeasurement for $monthlytargetMeasurement. Writing 0 as data point for this month."
-    fi    
-    insertStatement="INSERT ${monthlytargetMeasurement},year=${fYear},month=${fMonth} value=${energy} ${timestamp}"
+    fi
+    if [ "$additionalTags" != "" ]; then
+        insertStatement="INSERT ${monthlytargetMeasurement},year=${fYear},month=${fMonth},${additionalTags} value=${energy} ${timestamp}"
+    else
+        insertStatement="INSERT ${monthlytargetMeasurement},year=${fYear},month=${fMonth} value=${energy} ${timestamp}"
+    fi
     logDebug "Insert statement: $insertStatement"
     influx  -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_AGGR_DB -username "$INFLUX_AGGR_USER" -password "$INFLUX_AGGR_PASSWORD" -execute "$insertStatement"
 }
@@ -294,21 +334,21 @@ aggregateMonth() {
     writeMonthlyAggregations "sum" "value" "gridDailyEnergy" "gridMonthlyEnergy" $ayear $amonth
     writeMonthlyAggregations "sum" "value" "feedInDailyEnergy" "feedInMonthlyEnergy" $ayear $amonth
 
-    writeMonthlyAggregations "sum" "value" "loadpoint1DailyEnergy" "loadpoint1MonthlyEnergy" $ayear $amonth 
-    if [ "$LOADPOINT_2_ENABLED" == "true" ]; then
-        writeMonthlyAggregations "sum" "value" "loadpoint2DailyEnergy" "loadpoint2MonthlyEnergy" $ayear $amonth
-    else
-        logDebug "Loadpoint 2 is disabled."
-    fi
+    # writeMonthlyAggregations "sum" "value" "loadpoint1DailyEnergy" "loadpoint1MonthlyEnergy" $ayear $amonth 
+    # if [ "$LOADPOINT_2_ENABLED" == "true" ]; then
+    #     writeMonthlyAggregations "sum" "value" "loadpoint2DailyEnergy" "loadpoint2MonthlyEnergy" $ayear $amonth
+    # else
+    #     logDebug "Loadpoint 2 is disabled."
+    # fi
     
-    writeMonthlyAggregations "spread" "value" "vehicle1Odometer" "vehicle1DrivenKm" $ayear $amonth 
-    writeMonthlyAggregations "sum" "value" "vehicle1DailyEnergy" "vehicle1MonthlyEnergy" $ayear $amonth 
-    if [ "$VEHICLE_2_ENABLED" == "true" ]; then
-        writeMonthlyAggregations "spread" "value" "vehicle2Odometer" "vehicle2DrivenKm" $ayear $amonth 
-        writeMonthlyAggregations "sum" "value" "vehicle2DailyEnergy" "vehicle2MonthlyEnergy" $ayear $amonth 
-    else
-        logDebug "Vehicle 2 is disabled."
-    fi
+    # writeMonthlyAggregations "spread" "value" "vehicle1Odometer" "vehicle1DrivenKm" $ayear $amonth 
+    # writeMonthlyAggregations "sum" "value" "vehicle1DailyEnergy" "vehicle1MonthlyEnergy" $ayear $amonth 
+    # if [ "$VEHICLE_2_ENABLED" == "true" ]; then
+    #     writeMonthlyAggregations "spread" "value" "vehicle2Odometer" "vehicle2DrivenKm" $ayear $amonth 
+    #     writeMonthlyAggregations "sum" "value" "vehicle2DailyEnergy" "vehicle2MonthlyEnergy" $ayear $amonth 
+    # else
+    #     logDebug "Vehicle 2 is disabled."
+    # fi
 
     if [ "$HOME_BATTERY" == "true" ]; then
         writeMonthlyAggregations "sum" "value" "dischargeDailyEnergy" "dischargeMonthlyEnergy" $ayear $amonth
@@ -316,6 +356,19 @@ aggregateMonth() {
     else
         logDebug "Home battery aggregation is disabled"
     fi
+
+    for vehicle in "${VEHICLES[@]}"; do
+        logDebug "Aggregating vehicle $vehicle"
+        escapedVehicle=$(echo $vehicle | sed 's/ /\\ /g')
+        writeMonthlyAggregations "spread" "value" "vehicleOdometerDailyMax" "vehicleMonthlyDrivenKm" $ayear $amonth "AND \"vehicle\"::tag = '${vehicle}'" "vehicle=${escapedVehicle}"
+        writeMonthlyAggregations "sum" "value" "vehicleDailyEnergy" "vehicleMonthlyEnergy" $ayear $amonth "AND \"vehicle\"::tag = '${vehicle}'" "vehicle=${escapedVehicle}"
+    done
+
+    for loadpoint in "${LOADPOINTS[@]}"; do
+        logDebug "Aggregating loadpoint $loadpoint"
+        escapedLoadpoint=$(echo $loadpoint | sed 's/ /\\ /g')
+        writeMonthlyAggregations "sum" "value" "loadpointDailyEnergy" "loadpointMonthlyEnergy" $ayear $amonth "AND \"loadpoint\"::tag = '${loadpoint}'" "loadpoint=${escapedLoadpoint}"
+    done
 }
 
 dropMeasurement() {
@@ -338,16 +391,12 @@ dropAggregations() {
         sleep 1
         dropMeasurement "pvDailyEnergy"
         dropMeasurement "homeDailyEnergy"
-        dropMeasurement "loadpoint1DailyEnergy"
-        dropMeasurement "loadpoint2DailyEnergy"
         dropMeasurement "gridDailyEnergy"
         dropMeasurement "feedInDailyEnergy"
         dropMeasurement "dischargeDailyEnergy"
         dropMeasurement "chargeDailyEnergy"
         dropMeasurement "pvMonthlyEnergy"
         dropMeasurement "homeMonthlyEnergy"
-        dropMeasurement "loadpoint1MonthlyEnergy"
-        dropMeasurement "loadpoint2MonthlyEnergy"
         dropMeasurement "gridMonthlyEnergy"
         dropMeasurement "feedInMonthlyEnergy"
         dropMeasurement "dischargeMonthlyEnergy"
@@ -357,6 +406,18 @@ dropAggregations() {
         dropMeasurement "tariffGridDailyMax"
         dropMeasurement "tariffGridDailyMean"
         dropMeasurement "tariffGridDailyMin"
+        dropMeasurement "vehicleDailyEnergy"
+        dropMeasurement "vehicleMonthlyEnergy"
+        dropMeasurement "vehicleOdometerDailyMax"
+        dropMeasurement "vehicleMonthlyDrivenKm"
+        dropMeasurement "loadpointDailyEnergy"
+        dropMeasurement "loadpointMonthlyEnergy"
+
+        # Legacy measurements
+        dropMeasurement "loadpoint1DailyEnergy"
+        dropMeasurement "loadpoint2DailyEnergy"
+        dropMeasurement "loadpoint1MonthlyEnergy"
+        dropMeasurement "loadpoint2MonthlyEnergy"
         dropMeasurement "vehicle1DailyEnergy"
         dropMeasurement "vehicle1DrivenKm"
         dropMeasurement "vehicle1MonthlyEnergy"
@@ -368,6 +429,31 @@ dropAggregations() {
     else
         logInfo "Deletion of aggregated measurements aborted."
     fi
+}
+
+detectValues() {
+    # We are reading from vehicleOdometer as it typically contains entries for all vehicles and loadpoints, however has
+    # the least amount of records for a speedy query result.
+
+    # Detecting vehicles
+    index=0
+    vehicle_list=$(influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_EVCC_DB -username "$INFLUX_EVCC_USER" -password "$INFLUX_EVCC_PASSWORD" -execute "select min(value) from vehicleOdometer group by vehicle" | grep "tags: vehicle=" | sed "s/tags: vehicle=//" | grep -v "(offline)" | grep -v "^$" | sort)
+    while read vehicle; do
+        VEHICLES[${index}]=$vehicle
+        index=$((index+1))
+        logInfo "Detected vehicle $index: $vehicle"
+    done <<< "$vehicle_list"
+    logDebug "Detected ${#VEHICLES[*]} vehicles: ${VEHICLES[*]}"
+
+    # Detecting loadpoints
+    index=0
+    loadpoint_list=$(influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_EVCC_DB -username "$INFLUX_EVCC_USER" -password "$INFLUX_EVCC_PASSWORD" -execute "select min(value) from vehicleOdometer group by loadpoint" | grep "tags: loadpoint=" | sed "s/tags: loadpoint=//" | grep -v "^$" | sort)
+    while read loadpoint; do
+        LOADPOINTS[${index}]=$loadpoint
+        index=$((index+1))
+        logInfo "Detected loadpoint $index: $loadpoint"
+    done <<< "$loadpoint_list"
+    logDebug "Detected ${#LOADPOINTS[*]} vehicles: ${LOADPOINTS[*]}"
 }
 
 ###############################################################################
@@ -384,6 +470,7 @@ fi
 # Start aggregation
 if [ "$DELETE_AGGREGATIONS" != "true" ]; then
     logInfo "[`date '+%F %T'`] Starting aggregation..."
+    detectValues
 fi
 
 if [ "$AGGREGATE_YEAR" -ne 0 ]; then

--- a/scripts/evcc-influx-aggregate.sh
+++ b/scripts/evcc-influx-aggregate.sh
@@ -439,9 +439,11 @@ detectValues() {
     index=0
     vehicle_list=$(influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_EVCC_DB -username "$INFLUX_EVCC_USER" -password "$INFLUX_EVCC_PASSWORD" -execute "select min(value) from vehicleOdometer group by vehicle" | grep "tags: vehicle=" | sed "s/tags: vehicle=//" | grep -v "(offline)" | grep -v "^$" | sort)
     while read vehicle; do
-        VEHICLES[${index}]=$vehicle
-        index=$((index+1))
-        logInfo "Detected vehicle $index: $vehicle"
+        if [ "$vehicle" != "" ]; then
+            VEHICLES[${index}]=$vehicle
+            index=$((index+1))
+            logInfo "Detected vehicle $index: $vehicle"
+        fi
     done <<< "$vehicle_list"
     logDebug "Detected ${#VEHICLES[*]} vehicles: ${VEHICLES[*]}"
 
@@ -449,9 +451,11 @@ detectValues() {
     index=0
     loadpoint_list=$(influx -host "$INFLUX_HOST" -port $INFLUX_PORT -database $INFLUX_EVCC_DB -username "$INFLUX_EVCC_USER" -password "$INFLUX_EVCC_PASSWORD" -execute "select min(value) from vehicleOdometer group by loadpoint" | grep "tags: loadpoint=" | sed "s/tags: loadpoint=//" | grep -v "^$" | sort)
     while read loadpoint; do
-        LOADPOINTS[${index}]=$loadpoint
-        index=$((index+1))
-        logInfo "Detected loadpoint $index: $loadpoint"
+        if [ "$loadpoint" != "" ]; then
+            LOADPOINTS[${index}]=$loadpoint
+            index=$((index+1))
+            logInfo "Detected loadpoint $index: $loadpoint"
+        fi
     done <<< "$loadpoint_list"
     logDebug "Detected ${#LOADPOINTS[*]} vehicles: ${LOADPOINTS[*]}"
 }
@@ -469,8 +473,10 @@ fi
 
 # Start aggregation
 if [ "$DELETE_AGGREGATIONS" != "true" ]; then
-    logInfo "[`date '+%F %T'`] Starting aggregation..."
     detectValues
+    if [ "$DETECT_VALUES" != "true" ]; then
+        logInfo "[`date '+%F %T'`] Starting aggregation..."
+    fi
 fi
 
 if [ "$AGGREGATE_YEAR" -ne 0 ]; then


### PR DESCRIPTION
Closes #97
Closes #98

- Aggregation script detects all loadpoints and vehicles from database
- Aggregation script creates aggregation for all detected elements

Requires cleanup of aggregration database and re-run.